### PR TITLE
fix(intallation): information regarding the dispatcher added to the i…

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1197,13 +1197,17 @@ function handleStatusline(settings, isInteractive, callback) {
   Your current statusline:
     ${dim}command: ${existingCmd}${reset}
 
-  GSP includes a statusline showing:
+  GSP includes a smart dispatcher that auto-switches between
+  your existing statusline (GSD) and the GSP statusline based
+  on the current project type.
+
+  GSP statusline shows:
     * Model name
     * Current design phase + prettiness meter
     * Context window usage (color-coded)
 
-  ${cyan}1${reset}) Keep existing
-  ${cyan}2${reset}) Replace with GSP statusline\n`);
+  ${cyan}1${reset}) Keep existing (current statusline only)
+  ${cyan}2${reset}) Install dispatcher (auto-switches between both)\n`);
 
   rl.question(`  Choice ${dim}[1]${reset}: `, (answer) => {
     rl.close();


### PR DESCRIPTION
Right now, we have the following behavior during installation, as you can see in the print below:

When the statusline configuration for a tool such as 'get shit done' is found, a message regarding its replacement is show.

However, what actually happens during the installation is not this. Actually a dispatcher is installed, which seamlessly switches between both statusline configurations according to the current tool. This PR fixes the message giving the correct information.

<img width="457" height="485" alt="image" src="https://github.com/user-attachments/assets/b30f0010-3924-465b-b8d6-830050b9eab0" />
