### PR TITLE
docs: focus v0.7.3 changelog on pack updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,13 @@ All notable changes to get-shit-pretty are documented here.
 ## [0.7.3] — 2026-04-07
 
 ### Added
-- **Frosted glass bento card** — replaced broken `liquid-glass-react` WebGL with pure CSS `backdrop-filter` using glassmorphism style spec tokens (blur 12px, saturate 180%, indigo ambient shadows, gradient highlight overlay)
-- **Responsive ASCII hero** — stacked word layout (GET / SHIT / PRETTY) on mobile with `centerPad()` alignment, single `useBreakpoint` hook instead of 3 hidden instances
-- **Skills CLI install option** — `npx skills add jubscodes/get-shit-pretty` cherry-pick command added to the skills section
+- **Skills CLI support** — GSP is now discoverable via [The Agent Skills Directory](https://skills.sh/). Cherry-pick individual skills with `npx skills add jubscodes/get-shit-pretty`
 - **Bento grid reference** — `bento-grid.md` added to `gsp-project-build` with responsive layout patterns and common mistakes
 - **New skills in `/gsp-help`** — brand-brief, icons, logo, scaffold, design-system now listed
 
 ### Fixed
-- **Bento grid responsive layout** — single-column flex stack on mobile, 4-col grid on desktop with explicit per-card heights
-- **SVG wave edges visible** — oversized SVG container (`w-[120%]`) hides drift animation edges
 - **Help output corrections** — pipeline diagram (brief → research → ...), directory structure (patterns/ → system/), GitHub URL (jubscodes)
 - **Installer text** — "all commands" → "all skills" in post-install message
-
-### Changed
-- **Removed `liquid-glass-react` dependency** — zero production dependencies maintained
-- **npm audit fix** — resolved 2 moderate picomatch vulnerabilities in devDependencies
 
 ## [0.7.2] — 2026-04-04
 

--- a/README.md
+++ b/README.md
@@ -463,13 +463,13 @@ npx get-shit-pretty --codex --global --uninstall
 <details>
 <summary><strong>Cherry-pick skills</strong></summary>
 
-Don't need the full pack? Pick individual skills via the [skills CLI](https://github.com/nicepkg/skills):
+Don't need the full pack? Pick individual skills via [The Agent Skills Directory](https://skills.sh/):
 
 ```bash
 npx skills add jubscodes/get-shit-pretty
 ```
 
-Select the skills you want — no agents, hooks, or pipeline setup. Works with Claude Code.
+Select individual skills to install. Works with Claude Code, Cursor, Copilot, Gemini, and 20+ other agents.
 
 </details>
 

--- a/src/content/changelog/v0-7-3.mdx
+++ b/src/content/changelog/v0-7-3.mdx
@@ -1,44 +1,27 @@
 ---
-title: "v0.7.3 -- Landing page refresh, skills CLI"
+title: "v0.7.3 -- Skills CLI, help fixes"
 date: "2026-04-07T10:00:00"
-excerpt: "Frosted glass bento card, responsive ASCII hero, skills CLI cherry-pick install, and help output corrections."
-tags: ["landing-page", "responsive", "glassmorphism", "skills-cli"]
+excerpt: "GSP is now discoverable via The Agent Skills Directory. Cherry-pick individual skills, updated help output, and a new bento grid reference for project builds."
+tags: ["skills-cli", "help", "build-reference"]
 slug: "v0-7-3"
 ---
 
-## Frosted Glass Bento Card
+## Skills CLI Support
 
-The liquid glass style preset card used `liquid-glass-react` -- a WebGL library that didn't survive SSR and rendered as an empty orange blob. Replaced with pure CSS frosted glass using our own glassmorphism style spec tokens:
+GSP is now listed on [The Agent Skills Directory](https://skills.sh/). Users can cherry-pick individual skills without installing the full pack:
 
-```css
-backdrop-filter: blur(12px) saturate(180%);
-background: rgba(255, 255, 255, 0.12);
-border: 1px solid rgba(255, 255, 255, 0.20);
-box-shadow: 0 8px 32px rgba(31, 38, 135, 0.20),
-            inset 0 1px 0 rgba(255, 255, 255, 0.40);
-```
-
-The `liquid-glass-react` dependency was removed entirely -- zero production dependencies maintained.
-
-## Responsive ASCII Hero
-
-The "GET SHIT PRETTY" ASCII art was a single 110-character-wide block that scrolled horizontally on mobile. Now it uses a `useBreakpoint` hook to switch between:
-
-- **Desktop (lg+)**: full single-line layout
-- **Mobile/tablet**: stacked word blocks (GET / SHIT / PRETTY) with `centerPad()` alignment
-
-One interval runs the shimmer effect -- not three hidden instances.
-
-## Skills CLI Install
-
-GSP is now discoverable via the open skills ecosystem. The landing page skills section shows:
-
-```
+```bash
 npx skills add jubscodes/get-shit-pretty
 ```
 
-Users can cherry-pick individual skills without installing the full pack.
+This works with Claude Code, Cursor, Copilot, Gemini, and 20+ other agents. The full pack (`npx get-shit-pretty`) remains the recommended install for the complete pipeline with agents, hooks, and MCP servers.
 
-## Bento Grid Mobile Layout
+## Help Output Fixes
 
-The style presets bento grid uses `flex flex-col` on mobile (single-column stacked) and `lg:grid lg:grid-cols-4` on desktop. Each card has explicit mobile heights. SVG wave animations use percentage-based overflow (`w-[120%]`) to hide drift edges.
+`/gsp-help` now lists 5 skills that were missing: brand-brief, icons, logo, scaffold, and design-system. The pipeline diagram was corrected to show the current flow (brief -> research -> strategy -> identity -> guidelines), the directory structure updated (patterns/ -> system/), and the GitHub URL fixed.
+
+The installer post-install message now says "all skills" instead of "all commands".
+
+## Bento Grid Reference
+
+A new `bento-grid.md` reference was added to `gsp-project-build` -- responsive layout patterns for mixed-size card grids, breakpoint strategies, and common mistakes (like using `row-span` at small breakpoints).


### PR DESCRIPTION
Trim website-only changes from changelog, fix skills CLI link to skills.sh.