### PR TITLE
fix(installer): default non-interactive runs to local install

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1817,8 +1817,8 @@ function promptRuntime(callback) {
 
 function promptLocation(runtimes) {
   if (!process.stdin.isTTY) {
-    console.log(`  ${yellow}Non-interactive terminal detected, defaulting to global install${reset}\n`);
-    installAllRuntimes(runtimes, true, false);
+    console.log(`  ${yellow}Non-interactive terminal detected, defaulting to local (project) install${reset}\n`);
+    installAllRuntimes(runtimes, false, false);
     return;
   }
 
@@ -1898,8 +1898,8 @@ if (require.main === module) {
     installAllRuntimes(['claude'], hasGlobal, false);
   } else {
     if (!process.stdin.isTTY) {
-      console.log(`  ${yellow}Non-interactive terminal detected, defaulting to Claude Code global install${reset}\n`);
-      installAllRuntimes(['claude'], true, false);
+      console.log(`  ${yellow}Non-interactive terminal detected, defaulting to Claude Code local (project) install${reset}\n`);
+      installAllRuntimes(['claude'], false, false);
     } else {
       promptRuntime((runtimes) => {
         promptLocation(runtimes);


### PR DESCRIPTION
## Summary
- `npx get-shit-pretty` in a non-TTY terminal previously installed to `~/.claude` (global). Switched the non-interactive default to local (project) install in both branches of the install flow (`promptLocation` and the implicit `--claude` path).
- Updated the printed message to match: "defaulting to Claude Code local (project) install".

## Why
Local install is the safer default when the installer runs non-interactively (CI, piped invocations, AI tools spawning the command). It matches what most users want when running inside a project directory and avoids silently writing to the user's global config.

## Test plan
- [ ] `npx get-shit-pretty` in a non-TTY shell installs to `./.claude/` (not `~/.claude/`)
- [ ] Interactive runs still prompt for global vs local
- [ ] Explicit `--global` flag still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)