### PR TITLE
chore: recommend pnpm/bun for installation, drop npm/npx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ The `files` field in package.json controls what's included: `.mcp.json`, `bin`, 
 
 ### Dependencies rule
 
-The npm package must have **zero production dependencies**. The installer (`bin/install.js`) and scripts use only Node.js builtins. All deps (Next.js, React, shadcn, MDX, etc.) are for the local website (`src/`) and must stay in `devDependencies`. Never add a package to `dependencies` — it would be pulled in by every `npx get-shit-pretty` user for no reason.
+The npm package must have **zero production dependencies**. The installer (`bin/install.js`) and scripts use only Node.js builtins. All deps (Next.js, React, shadcn, MDX, etc.) are for the local website (`src/`) and must stay in `devDependencies`. Never add a package to `dependencies` — it would be pulled in by every `pnpm dlx get-shit-pretty` (or `bunx`) user for no reason.
 
 ## Dev tools
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 <br>
 
 ```bash
-npx get-shit-pretty
+pnpm dlx get-shit-pretty
+# or with bun
+bunx get-shit-pretty
 ```
 
 **Works on Mac, Windows, and Linux.**
@@ -50,8 +52,9 @@ Both disciplines. Same pipeline. Same environment. The missing half of the bridg
 ## Quick Start
 
 ```bash
-# 1. Install
-npx get-shit-pretty
+# 1. Install (pnpm or bun)
+pnpm dlx get-shit-pretty
+# bunx get-shit-pretty
 
 # 2. Define your brand — or skip with a style preset
 /gsp-brand-brief                    # guided brand definition
@@ -418,7 +421,9 @@ GSP works across all major AI coding tools. The installer converts Claude Code's
 ## Install
 
 ```bash
-npx get-shit-pretty
+pnpm dlx get-shit-pretty
+# or with bun
+bunx get-shit-pretty
 ```
 
 The installer prompts you to choose:
@@ -430,21 +435,23 @@ The installer prompts you to choose:
 
 ```bash
 # Claude Code
-npx get-shit-pretty --claude --global
-npx get-shit-pretty --claude --local
+pnpm dlx get-shit-pretty --claude --global
+pnpm dlx get-shit-pretty --claude --local
 
 # OpenCode
-npx get-shit-pretty --opencode --global
+pnpm dlx get-shit-pretty --opencode --global
 
 # Gemini CLI
-npx get-shit-pretty --gemini --global
+pnpm dlx get-shit-pretty --gemini --global
 
 # Codex CLI
-npx get-shit-pretty --codex --global
+pnpm dlx get-shit-pretty --codex --global
 
 # All runtimes
-npx get-shit-pretty --all --global
+pnpm dlx get-shit-pretty --all --global
 ```
+
+> Substitute `bunx` for `pnpm dlx` if you prefer bun.
 
 </details>
 
@@ -452,10 +459,10 @@ npx get-shit-pretty --all --global
 <summary><strong>Uninstall</strong></summary>
 
 ```bash
-npx get-shit-pretty --claude --global --uninstall
-npx get-shit-pretty --opencode --global --uninstall
-npx get-shit-pretty --gemini --global --uninstall
-npx get-shit-pretty --codex --global --uninstall
+pnpm dlx get-shit-pretty --claude --global --uninstall
+pnpm dlx get-shit-pretty --opencode --global --uninstall
+pnpm dlx get-shit-pretty --gemini --global --uninstall
+pnpm dlx get-shit-pretty --codex --global --uninstall
 ```
 
 </details>

--- a/bin/install.js
+++ b/bin/install.js
@@ -204,7 +204,7 @@ console.log(banner);
 
 // Help
 if (hasHelp) {
-  console.log(`  ${yellow}Usage:${reset} npx get-shit-pretty [options]\n
+  console.log(`  ${yellow}Usage:${reset} pnpm dlx get-shit-pretty [options]   ${dim}# or: bunx get-shit-pretty [options]${reset}\n
   ${yellow}Options:${reset}
     ${cyan}-g, --global${reset}              Install globally (to config directory)
     ${cyan}-l, --local${reset}               Install locally (to current directory)
@@ -221,19 +221,19 @@ if (hasHelp) {
 
   ${yellow}Examples:${reset}
     ${dim}# Interactive install (prompts for runtime and location)${reset}
-    npx get-shit-pretty
+    pnpm dlx get-shit-pretty
 
     ${dim}# Install for Claude Code globally${reset}
-    npx get-shit-pretty --claude --global
+    pnpm dlx get-shit-pretty --claude --global
 
     ${dim}# Install for all runtimes globally${reset}
-    npx get-shit-pretty --all --global
+    pnpm dlx get-shit-pretty --all --global
 
     ${dim}# Install to current project only${reset}
-    npx get-shit-pretty --claude --local
+    pnpm dlx get-shit-pretty --claude --local
 
     ${dim}# Uninstall GSP from Claude Code globally${reset}
-    npx get-shit-pretty --claude --global --uninstall
+    pnpm dlx get-shit-pretty --claude --global --uninstall
 `);
   process.exit(0);
 }

--- a/gsp/skills/get-shit-pretty/SKILL.md
+++ b/gsp/skills/get-shit-pretty/SKILL.md
@@ -11,7 +11,9 @@ Design engineering system for AI coding tools. Brand identity + design projects,
 ## Install
 
 ```bash
-npx get-shit-pretty
+pnpm dlx get-shit-pretty
+# or with bun
+bunx get-shit-pretty
 ```
 
 Pick your runtime (Claude Code, OpenCode, Gemini CLI, or Codex CLI), choose global or local install, and you're set.

--- a/gsp/skills/gsp-doctor/SKILL.md
+++ b/gsp/skills/gsp-doctor/SKILL.md
@@ -245,12 +245,12 @@ Glob for all SKILL.md files in the skills directory (`{runtime-dir}/skills/*/SKI
 **Check I2: Skill directories are complete (not just SKILL.md)**
 For each gsp-* skill directory, check if `SKILL.md` references sibling files via `${CLAUDE_SKILL_DIR}/` paths (e.g. `styles/INDEX.yml`). If it does, verify those files/dirs exist in the installed skill directory.
 - All referenced siblings present → PASS
-- Missing siblings → FAIL: "Skill {name} references {path} but it's missing. Re-run the installer: `npx get-shit-pretty`"
+- Missing siblings → FAIL: "Skill {name} references {path} but it's missing. Re-run the installer: `pnpm dlx get-shit-pretty` (or `bunx get-shit-pretty`)"
 
 **Check I3: Bundle directories accessible**
 Check that the runtime bundle directories exist (`{runtime-dir}/templates/`, `{runtime-dir}/references/`). Skills reference these via `${CLAUDE_SKILL_DIR}/../../`.
 - All present → PASS
-- Missing → FAIL: "Bundle directory {dir} missing. Re-run the installer: `npx get-shit-pretty`"
+- Missing → FAIL: "Bundle directory {dir} missing. Re-run the installer: `pnpm dlx get-shit-pretty` (or `bunx get-shit-pretty`)"
 
 **Check I4: VERSION file present**
 Check `{runtime-dir}/VERSION` exists and contains a valid semver string.
@@ -262,7 +262,7 @@ Check `{runtime-dir}/VERSION` exists and contains a valid semver string.
 Check if `~/.claude/skills/` contains `gsp-*` directories when running from a local install. These cause duplicates between global and local.
 - Run: `ls ~/.claude/skills/ | grep '^gsp-'`
 - No matches → PASS
-- Matches found → FAIL: "Found {N} stale GSP skills in ~/.claude/skills/. Fix: run `npx get-shit-pretty --claude --local` to reinstall (the installer cleans stale globals automatically), or manually remove: `rm -rf ~/.claude/skills/gsp-*`"
+- Matches found → FAIL: "Found {N} stale GSP skills in ~/.claude/skills/. Fix: run `pnpm dlx get-shit-pretty --claude --local` (or `bunx get-shit-pretty --claude --local`) to reinstall (the installer cleans stale globals automatically), or manually remove: `rm -rf ~/.claude/skills/gsp-*`"
 
 ### Stack Compliance Checks (shadcn targets)
 

--- a/gsp/skills/gsp-update/SKILL.md
+++ b/gsp/skills/gsp-update/SKILL.md
@@ -39,7 +39,9 @@ Record which runtime(s) and install type (local/global) were found.
 
 If no VERSION file exists anywhere, tell the user GSP doesn't appear to be installed and suggest:
 ```
-npx get-shit-pretty
+pnpm dlx get-shit-pretty
+# or with bun
+bunx get-shit-pretty
 ```
 Then stop.
 
@@ -103,14 +105,15 @@ Build the installer command based on what was detected in Step 1:
 **Scope flag:** `--local` if local install was detected, `--global` if global.
 
 ```bash
-npx get-shit-pretty@latest {runtime-flag} {scope-flag}
+pnpm dlx get-shit-pretty@latest {runtime-flag} {scope-flag}
+# or: bunx get-shit-pretty@latest {runtime-flag} {scope-flag}
 ```
 
 Examples:
-- Local Claude: `npx get-shit-pretty@latest --claude --local`
-- Global Claude: `npx get-shit-pretty@latest --claude --global`
-- Global OpenCode: `npx get-shit-pretty@latest --opencode --global`
-- Multiple runtimes: `npx get-shit-pretty@latest --all --global`
+- Local Claude: `pnpm dlx get-shit-pretty@latest --claude --local`
+- Global Claude: `pnpm dlx get-shit-pretty@latest --claude --global`
+- Global OpenCode: `pnpm dlx get-shit-pretty@latest --opencode --global`
+- Multiple runtimes: `pnpm dlx get-shit-pretty@latest --all --global`
 
 Show the output to the user.
 

--- a/install.sh
+++ b/install.sh
@@ -2,14 +2,14 @@
 set -e
 
 # NOTE: This is the legacy bash installer for Claude Code only.
-# The recommended method is: npx get-shit-pretty
-# The npm installer supports Claude Code, OpenCode, Gemini, and Codex.
+# The recommended method is: pnpm dlx get-shit-pretty   (or bunx get-shit-pretty)
+# The npm-published installer supports Claude Code, OpenCode, Gemini, and Codex.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLAUDE_DIR="$HOME/.claude"
 
 echo "🎨 Installing GSP — Get Shit Pretty (legacy bash installer)"
-echo "  Tip: Use 'npx get-shit-pretty' for multi-runtime support"
+echo "  Tip: Use 'pnpm dlx get-shit-pretty' (or 'bunx get-shit-pretty') for multi-runtime support"
 echo ""
 
 # Create target directories

--- a/src/components/install-command.tsx
+++ b/src/components/install-command.tsx
@@ -5,7 +5,7 @@ import { Copy, Check } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 
-const INSTALL_COMMAND = "npx get-shit-pretty";
+const INSTALL_COMMAND = "pnpm dlx get-shit-pretty";
 
 export function InstallCommand({ className, command }: { className?: string; command?: string }) {
   const [copied, setCopied] = useState(false);


### PR DESCRIPTION
## Summary
- Switch all install instructions from `npx get-shit-pretty` to `pnpm dlx get-shit-pretty` (primary) with `bunx get-shit-pretty` shown alongside.
- Touches: README, `bin/install.js` help output, `install.sh`, `CLAUDE.md`, `gsp-doctor`/`gsp-update`/`get-shit-pretty` skill messages, and the website install widget default.
- Historical changelog entries are left intact — they describe what shipped at the time.

## Why
We don't want to recommend npm/npx as the install path anymore. The package on the npm registry is unchanged, so `npx` keeps working for anyone who still pastes it; we just stop suggesting it.

## Implications
- Users without pnpm or bun installed will hit a missing-binary error before ever reaching our installer. Both are widely available (pnpm via `corepack`, bun via its own installer), but it is more friction than `npx`.
- The website's copy-button now hands out `pnpm dlx get-shit-pretty` — Mac/Linux users who copy-paste need pnpm available.
- No changes to publishing or build pipeline.

## Test plan
- [ ] `pnpm dlx get-shit-pretty` runs the same installer as before
- [ ] `bunx get-shit-pretty` runs the same installer
- [ ] `--help` output shows the new usage line and examples
- [ ] `bash dev/scripts/audit-tests.sh` passes (verified locally: 65 PASS, 2 pre-existing WARN)
- [ ] Website install widget shows the pnpm command in the copy field

🤖 Generated with [Claude Code](https://claude.com/claude-code)