### PR TITLE
chore: quick wins — icon library config + drop pass-through token refs

### DIFF
--- a/gsp/skills/gsp-brand-refine/SKILL.md
+++ b/gsp/skills/gsp-brand-refine/SKILL.md
@@ -26,7 +26,6 @@ Accept natural language feedback about brand visuals, identify which `.yml` valu
 </objective>
 
 <execution_context>
-@${CLAUDE_SKILL_DIR}/../gsp-brand-guidelines/design-tokens.md
 </execution_context>
 
 <rules>

--- a/gsp/skills/gsp-brand-sync/SKILL.md
+++ b/gsp/skills/gsp-brand-sync/SKILL.md
@@ -29,7 +29,6 @@ Compare a project's shipped state against its source brand across all dimensions
 </objective>
 
 <execution_context>
-@${CLAUDE_SKILL_DIR}/../gsp-brand-guidelines/design-tokens.md
 @${CLAUDE_SKILL_DIR}/chunk-format.md
 </execution_context>
 

--- a/gsp/skills/gsp-project-build/methodology/gsp-project-builder.md
+++ b/gsp/skills/gsp-project-build/methodology/gsp-project-builder.md
@@ -197,7 +197,7 @@ Every screen must pass these before marking complete. When `STYLE.md` is provide
 
 1. **Background treatment** — never plain white/dark. Subtle gradient, texture, or decorative element.
 2. **State polish** — hover/focus/active/pressed feel deliberate (shadow shifts, subtle scale, translateY) not just color swaps
-3. **Icon consistency** — one icon family, one stroke weight throughout
+3. **Icon consistency** — import from `preferences.icon_library` only (project config — defaults to `lucide`); one icon family, one stroke weight throughout. No mixing libraries within a screen
 4. **Image direction** — imagery style (photo/illustration/CSS-only) matches brand character
 5. **Responsive craft** — mobile is a designed experience, not just "it fits"
 

--- a/gsp/skills/gsp-scaffold/SKILL.md
+++ b/gsp/skills/gsp-scaffold/SKILL.md
@@ -179,6 +179,19 @@ When using the `@import "tailwindcss"` directive, scope the source to the app's 
 
 This limits scanning to `src/` and its siblings rather than the entire repo. Note that `shadcn init` may overwrite `globals.css` — if it does, verify its output still compiles. shadcn v4+ handles source scoping correctly in its own CSS output.
 
+## Step 3.9: Install configured icon library
+
+Read `preferences.icon_library` from project config (defaults to `lucide`).
+
+| Library | Action |
+|---------|--------|
+| `lucide` | No install — ships with shadcn (`lucide-react`) |
+| `phosphor` | `cd {APP_PATH} && {pkg-manager} add @phosphor-icons/react` |
+| `heroicons` | `cd {APP_PATH} && {pkg-manager} add @heroicons/react` |
+| `tabler` | `cd {APP_PATH} && {pkg-manager} add @tabler/icons-react` |
+
+If `shadcn info` already reports a different `iconLibrary` than the project config, log the divergence and use the project config's value (project config is the source of truth). Skip if `app_path` is empty (no codebase to install into).
+
 ## Step 4: Install components from manifest
 
 Read `{PROJECT_PATH}/brief/install-manifest.md` if it exists.

--- a/gsp/templates/branding/config.json
+++ b/gsp/templates/branding/config.json
@@ -18,5 +18,5 @@
     "style_preset": "",
     "style_base": []
   },
-  "gsp_version": "0.7.2"
+  "gsp_version": "0.9.1"
 }

--- a/gsp/templates/projects/config.json
+++ b/gsp/templates/projects/config.json
@@ -14,7 +14,8 @@
     "design_scope": "full",
     "style_preset": "",
     "repo_type": "single",
-    "app_path": ""
+    "app_path": "",
+    "icon_library": "lucide"
   },
   "git": {
     "branch": "",

--- a/gsp/templates/projects/config.json
+++ b/gsp/templates/projects/config.json
@@ -22,5 +22,5 @@
     "pr": "",
     "issue": ""
   },
-  "gsp_version": "0.7.2"
+  "gsp_version": "0.9.1"
 }


### PR DESCRIPTION
## Summary

Three small, low-risk wins from the issue cleanup pass:

### #175 — Icon library config (P2/XS)

- Add `preferences.icon_library` field to `gsp/templates/projects/config.json` (defaults to `lucide`)
- `gsp-scaffold` Step 3.9 installs the configured library when not Lucide (Lucide ships with shadcn)
- `gsp-project-builder` methodology rule extended: import from configured library only, no mixing within a screen

### #86 — design-tokens.md dedup (P0/XS)

`gsp-brand-refine` and `gsp-brand-sync` are pure-orchestrator skills (no agent spawn, no body reference to W3C format spec) — the `@`-loaded `design-tokens.md` was inert pass-through context. Removed both.

| Skill | Before | After | Δ |
|---|---|---|---|
| gsp-brand-refine | 369 | **184** | −50% |
| gsp-brand-sync   | 415 | **230** | −45% |

`gsp-style` keeps the `@`-ref (body line 39 cites the file as format spec). `gsp-brand-guidelines` uses its own colocated copy via `${CLAUDE_SKILL_DIR}/...` — no change.

### Housekeeping — `gsp_version` field bump

`gsp_version` field in `gsp/templates/{branding,projects}/config.json` was stuck at `0.7.2` — drifted across 6 releases. Field is metadata only (not read by any code) but should reflect the release where the template was last touched. Bumped to `0.9.1`.

## What I did NOT do

The proposed `patterns/` → `system/` source rename was a false positive. The on-disk `system/` directory in pre-v0.5.1 brands is migrated to `patterns/` by `gsp-update` (line 122) — the skill source's `patterns/` is the post-v0.5.1 convention, not drift.

## Test plan

- [x] `bash dev/scripts/audit-tests.sh` — 70 pass / 0 fail / 2 unrelated warns
- [x] Token budget delta verified on the two trimmed skills
- [x] Closes #175, #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)