### PR TITLE
feat: gspdev-eval-changes — quality eval for skill changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,7 @@ Internal development tools live in `dev/` (versioned in repo, never installed to
 | `dev/scripts/token-proxy-start.sh` | Live token proxy — mitmproxy addon for measuring real API usage |
 | `dev/scripts/benchmark.sh` | Token budget benchmarking — capture snapshots, compare against release baseline |
 | `dev/skills/gspdev-benchmark/` | Interactive benchmark skill — wraps benchmark.sh with analysis and suggestions |
+| `dev/skills/gspdev-eval-changes/` | Quality eval for skill/agent/methodology changes — parallel evaluators against parent SKILL.md, 6-dimension rubric. Run before merging non-trivial trims/refactors |
 | `dev/benchmarks/` | JSON snapshots — one per release, plus working comparisons |
 
 ### Running tests

--- a/dev/skills/gspdev-eval-changes/SKILL.md
+++ b/dev/skills/gspdev-eval-changes/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: gspdev-eval-changes
+description: Quality eval for skill/agent/methodology changes — spawns parallel evaluator agents that compare before/after against the parent SKILL.md using a fixed 6-dimension rubric. Use before merging non-trivial trims, refactors, or rewrites of files under `gsp/skills/` or `gsp/agents/`.
+user-invocable: true
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - Agent
+  - AskUserQuestion
+  - Edit
+argument-hint: "[<commit-range>] default: main..HEAD + uncommitted"
+---
+<context>
+GSP dev tool. After non-trivial changes to skill, agent, or methodology files, this skill verifies the change preserved substance — not just syntax. Catches lost rules, dropped output specs, vague rubric anchors, redundant prose recovered as essential signal, etc.
+
+Spawns one general-purpose evaluator agent per modified file in parallel. Each evaluator compares BEFORE (git history) and AFTER (working tree) against the parent SKILL.md using a fixed 6-dimension rubric, returns PASS / CONCERNS / FAIL with quoted findings and surgical recommendations.
+
+Different from siblings:
+- `/gspdev-audit` — static checks across the whole repo (contracts, installer, version sync). Read-only, no eval.
+- `/gspdev-housekeeping` — drift detection (count mismatches, stale references). Mechanical.
+- `/gspdev-prompt-audit` — semantic analysis of all skill prompts (dead weight, contradictions). Whole-repo, slow.
+
+This skill is targeted: it evaluates the quality of a *specific change* before it merges.
+</context>
+
+<objective>
+Verify quality preservation after non-trivial changes to skill, agent, or methodology files.
+
+**Input:** Optional commit range (default: `main..HEAD` + uncommitted)
+**Output:** Aggregated verdict table + per-file findings; optional inline restoration of CONCERNS-flagged content
+**Agent:** general-purpose (one per evaluated file, dispatched in parallel)
+</objective>
+
+<rules>
+- Always use `AskUserQuestion` for user interaction
+- Never modify files without explicit confirmation
+- Skip files smaller than 30 lines unless they are SKILL.md (too small to need eval)
+- Skip pure additions (BEFORE empty or new file) — eval is for trims/refactors
+- All evaluator Agent calls must be dispatched in a single message for parallel execution
+</rules>
+
+<process>
+
+## Step 0: Resolve scope
+
+Determine which files to evaluate:
+
+1. If `$ARGUMENTS` contains a commit range (e.g., `main..HEAD`, `HEAD~3..HEAD`, `feature-branch..main`), use it directly
+2. Otherwise default to `main..HEAD` plus uncommitted working-tree changes
+
+```bash
+RANGE="${ARGUMENTS:-main..HEAD}"
+
+# Committed changes in range
+COMMITTED=$(git diff --name-only "$RANGE" 2>/dev/null | grep -E '^(gsp|dev)/(skills|agents)/.*\.md$' || true)
+
+# Uncommitted working-tree changes
+UNCOMMITTED=$(git diff --name-only HEAD 2>/dev/null | grep -E '^(gsp|dev)/(skills|agents)/.*\.md$' || true)
+
+# Combine, dedupe
+FILES=$(printf "%s\n%s\n" "$COMMITTED" "$UNCOMMITTED" | sort -u | grep -v '^$')
+```
+
+## Step 1: Filter to eval-worthy changes
+
+For each candidate file:
+- Skip if BEFORE doesn't exist in `${BEFORE_REF}` (new file — eval doesn't apply)
+- Skip if AFTER doesn't exist (deleted file — different concern; user should review the deletion intentionally)
+- Skip if file is < 30 lines AND not a `SKILL.md` (too small to warrant a full eval)
+- Otherwise include in the eval set
+
+If 0 files survive: print `No eval-worthy changes. Run \`git diff $RANGE\` to see what changed.` and exit cleanly.
+
+## Step 2: Stage before/after
+
+```bash
+TMPDIR=$(mktemp -d /tmp/gspdev-eval-XXXXXX)
+BEFORE_REF="${RANGE%..*}"
+[[ -z "$BEFORE_REF" ]] && BEFORE_REF="main"
+
+for f in $FILES; do
+  base=$(echo "$f" | tr '/' '_' | sed 's/\.md$//')
+  git show "${BEFORE_REF}:$f" > "$TMPDIR/${base}-before.md" 2>/dev/null
+  cp "$f" "$TMPDIR/${base}-after.md"
+done
+```
+
+## Step 3: Identify parent SKILL.md per file
+
+Each evaluator needs the parent skill for context:
+
+| File pattern | Parent for context |
+|---|---|
+| `gsp/skills/{name}/SKILL.md` | itself |
+| `gsp/skills/{name}/methodology/*.md` | `gsp/skills/{name}/SKILL.md` |
+| `gsp/skills/{name}/{sibling}.md` | `gsp/skills/{name}/SKILL.md` |
+| `gsp/agents/{name}.md` | none — agent stub stands alone |
+| `dev/skills/{name}/...` | analogous to gsp/skills/ |
+
+## Step 4: Load rubric
+
+Read `${CLAUDE_SKILL_DIR}/rubric.md` — this is the standard evaluation rubric inlined into every evaluator's prompt.
+
+## Step 5: Spawn parallel evaluators
+
+For each file, spawn one Agent call with `subagent_type: "general-purpose"` and `run_in_background: true`. **Dispatch all Agent calls in a single message** for true parallelism.
+
+Each evaluator prompt:
+
+```
+Evaluate quality preservation in this file change.
+
+Context: GSP design engineering framework. Today is {DATE}; current release is {VERSION}. The file you are evaluating is loaded into an agent's context every time the parent skill is invoked, so substance loss directly affects agent output quality.
+
+File: {RELATIVE_PATH}
+BEFORE: {TMPDIR}/{base}-before.md ({BEFORE_LINES} lines)
+AFTER:  {TMPDIR}/{base}-after.md ({AFTER_LINES} lines, {DELTA}%)
+Parent SKILL.md (for context, may be the same as AFTER if file is itself a SKILL.md): {PARENT_PATH}
+
+[INLINE RUBRIC — verbatim from {CLAUDE_SKILL_DIR}/rubric.md]
+
+Output exactly this structure (markdown, under 600 words):
+
+### Verdict: PASS / CONCERNS / FAIL
+
+### Per-dimension scores
+
+| Dimension | Score | Notes |
+
+### Specific findings (if any)
+
+Quoted BEFORE text + recommendation (restore / leave / discuss).
+
+### Net assessment
+
+One paragraph: did the change improve the file (or land its intent) without sacrificing the agent's ability to do its job?
+
+Do NOT modify any files. Report only.
+```
+
+## Step 6: Aggregate verdicts
+
+Wait for all evaluators (notifications arrive automatically). Compose summary:
+
+```markdown
+## Quality eval — {N} files
+
+| File | Δ lines | Verdict | Concerns |
+|------|---------|---------|----------|
+| ... | ... | PASS | 0 |
+| ... | ... | CONCERNS | 1 (restore X) |
+```
+
+Print the per-file detail underneath in collapsible form (the evaluator output verbatim).
+
+## Step 7: Surface concerns + offer fixes
+
+If any CONCERNS or FAIL verdicts exist:
+
+Use `AskUserQuestion`: "{N} files flagged concerns. Apply suggested restorations?"
+
+Options:
+- **Apply** — for each CONCERN, restore the flagged content per evaluator's recommendation. Edit files inline. Re-run audit suite to confirm nothing breaks.
+- **Walk individually** — present each concern, ask per-finding (apply / skip / discuss)
+- **Skip** — record concerns in the report but make no changes (user will address manually or in PR review)
+
+If all PASS: print `All {N} files PASS. Ready to merge.` and exit.
+
+## Step 8: Cleanup
+
+```bash
+rm -rf "$TMPDIR"
+```
+
+Print final summary:
+
+```
+N files evaluated
+  ✓ N PASS
+  ! N CONCERNS  ({applied|skipped|walked})
+  ✗ N FAIL  ({reverted|surfaced})
+
+Recommended action: {merge | fix-then-merge | revert-and-redesign}
+```
+
+</process>
+
+<output>
+Terminal report (markdown). Optional inline file edits if the user picks Apply / Walk in Step 7. No persistent artifacts written outside `$TMPDIR` (which is cleaned up at exit).
+</output>

--- a/dev/skills/gspdev-eval-changes/SKILL.md
+++ b/dev/skills/gspdev-eval-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gspdev-eval-changes
-description: Quality eval for skill/agent/methodology changes — spawns parallel evaluator agents that compare before/after against the parent SKILL.md using a fixed 6-dimension rubric. Use before merging non-trivial trims, refactors, or rewrites of files under `gsp/skills/` or `gsp/agents/`.
+description: Quality eval for skill/agent/methodology changes — spawns parallel evaluator agents that compare before/after against the parent SKILL.md using a fixed 7-dimension rubric (intent achievement + 6 preservation dimensions). Use before merging non-trivial trims, refactors, or rewrites of files under `gsp/skills/` or `gsp/agents/`.
 user-invocable: true
 allowed-tools:
   - Read
@@ -13,9 +13,14 @@ allowed-tools:
 argument-hint: "[<commit-range>] default: main..HEAD + uncommitted"
 ---
 <context>
-GSP dev tool. After non-trivial changes to skill, agent, or methodology files, this skill verifies the change preserved substance — not just syntax. Catches lost rules, dropped output specs, vague rubric anchors, redundant prose recovered as essential signal, etc.
+GSP dev tool. After non-trivial changes to skill, agent, or methodology files, this skill verifies two things in order:
 
-Spawns one general-purpose evaluator agent per modified file in parallel. Each evaluator compares BEFORE (git history) and AFTER (working tree) against the parent SKILL.md using a fixed 6-dimension rubric, returns PASS / CONCERNS / FAIL with quoted findings and surgical recommendations.
+1. **Did the change land its stated intent?** (the "why" of the change)
+2. **Did the change preserve substance?** (the "what shouldn't have moved")
+
+A trim that drops 50% of a file but doesn't actually achieve the perf goal isn't a win, regardless of how clean the cuts were. Conversely, a refactor that lands its intent but breaks an output spec isn't ready to ship either. Both gates matter.
+
+Spawns one general-purpose evaluator agent per modified file in parallel. Each evaluator compares BEFORE (git history) and AFTER (working tree) against the parent SKILL.md using a fixed 7-dimension rubric (intent achievement + 6 preservation dimensions), returns PASS / CONCERNS / FAIL with quoted findings and surgical recommendations.
 
 Different from siblings:
 - `/gspdev-audit` — static checks across the whole repo (contracts, installer, version sync). Read-only, no eval.
@@ -103,16 +108,37 @@ Each evaluator needs the parent skill for context:
 
 Read `${CLAUDE_SKILL_DIR}/rubric.md` — this is the standard evaluation rubric inlined into every evaluator's prompt.
 
-## Step 5: Spawn parallel evaluators
+## Step 5: Extract intent
+
+Before spawning evaluators, extract the change's stated intent — what the author was trying to accomplish. Sources, in order of preference:
+
+1. **PR description** (if a PR exists for the branch) — `gh pr view --json body` and parse for goals/motivation
+2. **Commit messages in range** — `git log $RANGE --format='%s%n%n%b'`. The commit subject + body usually states intent
+3. **Branch name** — sometimes signals (e.g., `perf/85-trim-methodology` → "trim methodology"). Weak signal; use only if 1-2 are absent
+
+Compose a one-paragraph **intent statement** that names the change's goal in concrete terms (target metric, structural outcome, behavior change).
+
+If sources are silent or contradictory, use `AskUserQuestion`:
+- Question: "What was the intent of this change? (one sentence)"
+- Options: free-form text via Other
+
+If the user skips: pass `Intent: not provided — defensive eval only` to each evaluator. The evaluators will skip Dimension 1 and score 2-7 only.
+
+## Step 6: Spawn parallel evaluators
 
 For each file, spawn one Agent call with `subagent_type: "general-purpose"` and `run_in_background: true`. **Dispatch all Agent calls in a single message** for true parallelism.
 
 Each evaluator prompt:
 
 ```
-Evaluate quality preservation in this file change.
+Evaluate intent achievement + quality preservation in this file change.
 
 Context: GSP design engineering framework. Today is {DATE}; current release is {VERSION}. The file you are evaluating is loaded into an agent's context every time the parent skill is invoked, so substance loss directly affects agent output quality.
+
+**Intent of this change (extracted in Step 5):**
+{INTENT_STATEMENT}
+
+(If "not provided", skip Dimension 1 and score Dimensions 2-7 as defensive eval only.)
 
 File: {RELATIVE_PATH}
 BEFORE: {TMPDIR}/{base}-before.md ({BEFORE_LINES} lines)
@@ -121,26 +147,32 @@ Parent SKILL.md (for context, may be the same as AFTER if file is itself a SKILL
 
 [INLINE RUBRIC — verbatim from {CLAUDE_SKILL_DIR}/rubric.md]
 
-Output exactly this structure (markdown, under 600 words):
+Output exactly this structure (markdown, under 700 words):
 
 ### Verdict: PASS / CONCERNS / FAIL
+
+### Intent achievement
+
+One paragraph: did the change land its stated intent? Cite specific evidence from the diff (e.g., "Trim claimed -34%, actual was 188→125L = 33.5% — within target").
 
 ### Per-dimension scores
 
 | Dimension | Score | Notes |
 
+(Skip Dimension 1 row if intent was not provided.)
+
 ### Specific findings (if any)
 
-Quoted BEFORE text + recommendation (restore / leave / discuss).
+Quoted BEFORE text + recommendation (restore / leave / discuss / redesign-intent).
 
 ### Net assessment
 
-One paragraph: did the change improve the file (or land its intent) without sacrificing the agent's ability to do its job?
+One paragraph: did the change land its intent AND preserve the agent's ability to do its job? Direct verdict: ship / ship after restoring X / revert and redesign.
 
 Do NOT modify any files. Report only.
 ```
 
-## Step 6: Aggregate verdicts
+## Step 7: Aggregate verdicts
 
 Wait for all evaluators (notifications arrive automatically). Compose summary:
 
@@ -155,20 +187,25 @@ Wait for all evaluators (notifications arrive automatically). Compose summary:
 
 Print the per-file detail underneath in collapsible form (the evaluator output verbatim).
 
-## Step 7: Surface concerns + offer fixes
+## Step 8: Surface concerns + offer fixes
 
-If any CONCERNS or FAIL verdicts exist:
+Concerns split into two categories per the new rubric:
 
-Use `AskUserQuestion`: "{N} files flagged concerns. Apply suggested restorations?"
+**Intent-related (Dimension 1):**
+- If any file's Dimension 1 is FAIL → the change didn't land its intent. Surface as: "Intent FAIL on {N} file(s). The change does not achieve {INTENT_STATEMENT}. Recommend redesigning the change before merging."
+- If any file's Dimension 1 is CONCERNS → intent partially achieved (e.g., trim hit 8% when target was 30%). Surface as: "Intent CONCERNS — gap between target and result on {N} file(s)."
+
+**Preservation-related (Dimensions 2-7):**
+Use `AskUserQuestion`: "{N} files flagged preservation concerns. Apply suggested restorations?"
 
 Options:
-- **Apply** — for each CONCERN, restore the flagged content per evaluator's recommendation. Edit files inline. Re-run audit suite to confirm nothing breaks.
+- **Apply** — for each CONCERN, restore the flagged content per evaluator's recommendation. Edit files inline. Re-run audit suite to confirm nothing breaks
 - **Walk individually** — present each concern, ask per-finding (apply / skip / discuss)
 - **Skip** — record concerns in the report but make no changes (user will address manually or in PR review)
 
-If all PASS: print `All {N} files PASS. Ready to merge.` and exit.
+If all dimensions PASS across all files: print `All {N} files PASS. Intent achieved + substance preserved. Ready to merge.` and exit.
 
-## Step 8: Cleanup
+## Step 9: Cleanup
 
 ```bash
 rm -rf "$TMPDIR"
@@ -178,9 +215,13 @@ Print final summary:
 
 ```
 N files evaluated
-  ✓ N PASS
+Intent: {INTENT_STATEMENT_SHORT}
+
+  ✓ N PASS  (intent achieved + substance preserved)
   ! N CONCERNS  ({applied|skipped|walked})
   ✗ N FAIL  ({reverted|surfaced})
+
+Intent verdict: {achieved | partial | not-achieved}
 
 Recommended action: {merge | fix-then-merge | revert-and-redesign}
 ```

--- a/dev/skills/gspdev-eval-changes/SKILL.md
+++ b/dev/skills/gspdev-eval-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gspdev-eval-changes
-description: Quality eval for skill/agent/methodology changes — spawns parallel evaluator agents that compare before/after against the parent SKILL.md using a fixed 7-dimension rubric (intent achievement + 6 preservation dimensions). Use before merging non-trivial trims, refactors, or rewrites of files under `gsp/skills/` or `gsp/agents/`.
+description: Quality eval for any non-trivial change to skill/agent/methodology files — spawns parallel evaluator agents that score against a fixed 8-dimension rubric (change intent + skill intent coherence + 6 preservation dimensions). Covers additions, modifications, refactors, trims, and rewrites under `gsp/skills/` or `gsp/agents/`. Use before merging.
 user-invocable: true
 allowed-tools:
   - Read
@@ -13,14 +13,25 @@ allowed-tools:
 argument-hint: "[<commit-range>] default: main..HEAD + uncommitted"
 ---
 <context>
-GSP dev tool. After non-trivial changes to skill, agent, or methodology files, this skill verifies two things in order:
+GSP dev tool. Applies to **any** non-trivial change — additions, modifications, refactors, trims, rewrites. Verifies three things in order:
 
-1. **Did the change land its stated intent?** (the "why" of the change)
-2. **Did the change preserve substance?** (the "what shouldn't have moved")
+1. **Change intent achieved?** Did the PR/commit land what it set out to do?
+2. **Skill intent coherent?** Does the skill body deliver on its description? (Catches drift between SKILL.md frontmatter `description:` and the body — a separate failure mode from the change-intent question.)
+3. **Substance preserved or improved?** For modifications: did the change avoid sacrificing what the agent needs? For additions: does the new content fit the skill's existing contracts (constraints, output specs, quality bars)?
 
-A trim that drops 50% of a file but doesn't actually achieve the perf goal isn't a win, regardless of how clean the cuts were. Conversely, a refactor that lands its intent but breaks an output spec isn't ready to ship either. Both gates matter.
+Examples of changes this covers:
+- Adding a new step to a methodology
+- Adding a new sibling reference file
+- Modifying a rule, constraint, or rubric
+- Changing the agent's role or execution mode
+- Trimming verbose prose
+- Extracting content to siblings
+- Renaming inputs/outputs
+- Adding a new SKILL.md (skill intent check from scratch)
 
-Spawns one general-purpose evaluator agent per modified file in parallel. Each evaluator compares BEFORE (git history) and AFTER (working tree) against the parent SKILL.md using a fixed 7-dimension rubric (intent achievement + 6 preservation dimensions), returns PASS / CONCERNS / FAIL with quoted findings and surgical recommendations.
+A change that achieves its goal (Dim 1 = PASS) can still drift the skill away from its stated purpose (Dim 2 = FAIL) if it adds behavior the description doesn't reflect, or removes a step the description promised. A coherent intent + description (Dims 1-2 = PASS) can still break an output spec (Dim 6 = FAIL). All three gates matter.
+
+Spawns one general-purpose evaluator agent per modified file in parallel. Each evaluator compares BEFORE (if any) and AFTER against the parent SKILL.md using a fixed 8-dimension rubric, returns PASS / CONCERNS / FAIL with quoted findings and surgical recommendations.
 
 Different from siblings:
 - `/gspdev-audit` — static checks across the whole repo (contracts, installer, version sync). Read-only, no eval.
@@ -41,8 +52,9 @@ Verify quality preservation after non-trivial changes to skill, agent, or method
 <rules>
 - Always use `AskUserQuestion` for user interaction
 - Never modify files without explicit confirmation
-- Skip files smaller than 30 lines unless they are SKILL.md (too small to need eval)
-- Skip pure additions (BEFORE empty or new file) — eval is for trims/refactors
+- Skip files smaller than 30 lines unless they are SKILL.md (too small to warrant a full eval)
+- New files (BEFORE doesn't exist) are evaluated against Dimensions 1-2 only — preservation dimensions 3-8 are scored "N/A — new file, no regression possible"
+- Deleted files (AFTER doesn't exist) are flagged for separate review (Dim 2 — was the description updated to match the deletion?) but not auto-evaluated
 - All evaluator Agent calls must be dispatched in a single message for parallel execution
 </rules>
 
@@ -68,15 +80,20 @@ UNCOMMITTED=$(git diff --name-only HEAD 2>/dev/null | grep -E '^(gsp|dev)/(skill
 FILES=$(printf "%s\n%s\n" "$COMMITTED" "$UNCOMMITTED" | sort -u | grep -v '^$')
 ```
 
-## Step 1: Filter to eval-worthy changes
+## Step 1: Filter and classify changes
 
-For each candidate file:
-- Skip if BEFORE doesn't exist in `${BEFORE_REF}` (new file — eval doesn't apply)
-- Skip if AFTER doesn't exist (deleted file — different concern; user should review the deletion intentionally)
-- Skip if file is < 30 lines AND not a `SKILL.md` (too small to warrant a full eval)
-- Otherwise include in the eval set
+For each candidate file, classify into one of:
+
+| Classification | Condition | Treatment |
+|---|---|---|
+| **modified** | BEFORE exists + AFTER exists | Full 8-dimension eval |
+| **new** | BEFORE doesn't exist + AFTER exists | Evaluate Dims 1-2 only; mark Dims 3-8 as N/A |
+| **deleted** | BEFORE exists + AFTER doesn't | Flag for manual review (was description updated to match the deletion?). Skip parallel eval |
+| **trivial** | < 30 lines AND not a SKILL.md | Skip — too small to warrant eval |
 
 If 0 files survive: print `No eval-worthy changes. Run \`git diff $RANGE\` to see what changed.` and exit cleanly.
+
+If only deleted files: print `{N} deleted files — review manually that the parent SKILL.md description still matches the body. Skipping eval.` and exit.
 
 ## Step 2: Stage before/after
 
@@ -87,10 +104,14 @@ BEFORE_REF="${RANGE%..*}"
 
 for f in $FILES; do
   base=$(echo "$f" | tr '/' '_' | sed 's/\.md$//')
-  git show "${BEFORE_REF}:$f" > "$TMPDIR/${base}-before.md" 2>/dev/null
+  # BEFORE may not exist (new file) — capture empty
+  git show "${BEFORE_REF}:$f" > "$TMPDIR/${base}-before.md" 2>/dev/null || \
+    : > "$TMPDIR/${base}-before.md"
   cp "$f" "$TMPDIR/${base}-after.md"
 done
 ```
+
+For files classified as `new` in Step 1, the BEFORE file is empty — evaluators handle this by scoring Dim 1-2 only.
 
 ## Step 3: Identify parent SKILL.md per file
 
@@ -108,21 +129,37 @@ Each evaluator needs the parent skill for context:
 
 Read `${CLAUDE_SKILL_DIR}/rubric.md` — this is the standard evaluation rubric inlined into every evaluator's prompt.
 
-## Step 5: Extract intent
+## Step 5: Extract change intent
 
-Before spawning evaluators, extract the change's stated intent — what the author was trying to accomplish. Sources, in order of preference:
+Extract the change's stated intent — what the author was trying to accomplish. Sources, in order of preference:
 
 1. **PR description** (if a PR exists for the branch) — `gh pr view --json body` and parse for goals/motivation
 2. **Commit messages in range** — `git log $RANGE --format='%s%n%n%b'`. The commit subject + body usually states intent
 3. **Branch name** — sometimes signals (e.g., `perf/85-trim-methodology` → "trim methodology"). Weak signal; use only if 1-2 are absent
 
-Compose a one-paragraph **intent statement** that names the change's goal in concrete terms (target metric, structural outcome, behavior change).
+Compose a one-paragraph **change intent statement** that names the goal in concrete terms (target metric, structural outcome, behavior change).
 
 If sources are silent or contradictory, use `AskUserQuestion`:
 - Question: "What was the intent of this change? (one sentence)"
 - Options: free-form text via Other
 
-If the user skips: pass `Intent: not provided — defensive eval only` to each evaluator. The evaluators will skip Dimension 1 and score 2-7 only.
+If the user skips: pass `Change intent: not provided — defensive eval only` to each evaluator. The evaluators will skip Dimension 1 and score 2-8 only.
+
+## Step 5.5: Extract skill intent (per file)
+
+For each file in the eval set, extract the **skill intent** — what the parent skill is supposed to do (independent of the current change).
+
+For each file, locate the relevant SKILL.md (file itself if it IS a SKILL.md, otherwise the parent at `gsp/skills/{name}/SKILL.md` or `dev/skills/{name}/SKILL.md`):
+
+1. Read the `description:` field from frontmatter
+2. Read the `<context>` block — purpose, when to use
+3. Read the `<objective>` block — input → output contract, agent responsibilities
+
+Compose a one-sentence **skill intent statement** capturing the skill's stated purpose.
+
+If the change touches the SKILL.md itself, capture both BEFORE and AFTER skill intent — the evaluator will compare them.
+
+This per-file skill intent is passed to each evaluator alongside the change intent.
 
 ## Step 6: Spawn parallel evaluators
 
@@ -131,43 +168,55 @@ For each file, spawn one Agent call with `subagent_type: "general-purpose"` and 
 Each evaluator prompt:
 
 ```
-Evaluate intent achievement + quality preservation in this file change.
+Evaluate change intent + skill intent + quality preservation in this file change.
 
 Context: GSP design engineering framework. Today is {DATE}; current release is {VERSION}. The file you are evaluating is loaded into an agent's context every time the parent skill is invoked, so substance loss directly affects agent output quality.
 
-**Intent of this change (extracted in Step 5):**
-{INTENT_STATEMENT}
+**Classification:** {modified | new}
+(For `new` files: score Dimensions 1-2 only; mark 3-8 as N/A — no BEFORE to regress against.)
 
-(If "not provided", skip Dimension 1 and score Dimensions 2-7 as defensive eval only.)
+**Change intent (extracted in Step 5):**
+{CHANGE_INTENT_STATEMENT}
+
+(If "not provided", skip Dimension 1 and score Dimensions 2-8.)
+
+**Skill intent (extracted in Step 5.5):**
+{SKILL_INTENT_STATEMENT}
+
+(If the file under eval IS a SKILL.md and the description/context/objective changed, also include BEFORE skill intent for drift comparison.)
 
 File: {RELATIVE_PATH}
-BEFORE: {TMPDIR}/{base}-before.md ({BEFORE_LINES} lines)
+BEFORE: {TMPDIR}/{base}-before.md ({BEFORE_LINES} lines, may be empty for new files)
 AFTER:  {TMPDIR}/{base}-after.md ({AFTER_LINES} lines, {DELTA}%)
 Parent SKILL.md (for context, may be the same as AFTER if file is itself a SKILL.md): {PARENT_PATH}
 
 [INLINE RUBRIC — verbatim from {CLAUDE_SKILL_DIR}/rubric.md]
 
-Output exactly this structure (markdown, under 700 words):
+Output exactly this structure (markdown, under 800 words):
 
 ### Verdict: PASS / CONCERNS / FAIL
 
-### Intent achievement
+### Change intent achievement
 
 One paragraph: did the change land its stated intent? Cite specific evidence from the diff (e.g., "Trim claimed -34%, actual was 188→125L = 33.5% — within target").
+
+### Skill intent coherence
+
+One paragraph: does the AFTER body deliver on the skill intent? If the SKILL.md description/context/objective changed, was the body change coherent with it? Cite specific drift if any (e.g., "description still says 'spawns 4 agents' but body now spawns 3").
 
 ### Per-dimension scores
 
 | Dimension | Score | Notes |
 
-(Skip Dimension 1 row if intent was not provided.)
+(Skip Dimension 1 row if change intent was not provided.)
 
 ### Specific findings (if any)
 
-Quoted BEFORE text + recommendation (restore / leave / discuss / redesign-intent).
+Quoted BEFORE text + recommendation (restore / leave / discuss / redesign-intent / align-description).
 
 ### Net assessment
 
-One paragraph: did the change land its intent AND preserve the agent's ability to do its job? Direct verdict: ship / ship after restoring X / revert and redesign.
+One paragraph: did the change land BOTH intents AND preserve the agent's ability to do its job? Direct verdict: ship / ship after restoring X / align description / revert and redesign.
 
 Do NOT modify any files. Report only.
 ```

--- a/dev/skills/gspdev-eval-changes/rubric.md
+++ b/dev/skills/gspdev-eval-changes/rubric.md
@@ -1,0 +1,89 @@
+# Skill change evaluation rubric
+
+Six dimensions. Each scored **PASS / CONCERNS / FAIL**. Score against the AFTER file using BEFORE and the parent SKILL.md as context.
+
+## 1. Role + execution mode preservation
+
+Does the agent still know what it is and when to apply different modes?
+
+- `<role>` block intact — agent identity, persona, mandate
+- Execution modes (e.g. revision, foundations vs screen vs component) still distinguishable
+- Custom-input handling (references, fixes, brand context) preserved
+
+**Concerns flag:** mode disambiguation softened, role drift, lost handling for an input the parent skill still passes.
+
+## 2. Methodology completeness
+
+Every numbered step / decision point / phase still present?
+
+- Numbered steps (Step 0, Steps 1-N, Step 9, etc.) preserved in count and order
+- Conditional branches (if-then logic) preserved
+- Per-step inputs and outputs still specified
+
+**Concerns flag:** a step removed, a conditional collapsed, an input/output left implicit.
+
+## 3. Constraints + rules preservation
+
+Are binding rules still binding?
+
+- "Always" / "never" lists preserved
+- Auto-fail conditions (e.g., "constraint violation = automatic Fail") still explicit
+- Validation gates and quality bars unchanged
+- Severity language (Critical, Important) still used consistently
+
+**Concerns flag:** a constraint dropped, severity softened (must → should), validation gate weakened.
+
+## 4. Output specification clarity
+
+Can the agent still produce the expected deliverables without ambiguity?
+
+- File names and paths specified
+- Per-file content requirements clear
+- Cross-references between deliverables intact
+- INDEX.md / index file structure preserved
+- Line targets, formatting hints, schema references all present
+
+**Concerns flag:** a deliverable's structure became implicit, a path got vague, schema dropped without recoverable description.
+
+## 5. Distilled references actionable
+
+Compressed reference lists (HIG, anti-patterns, scoring rubrics) still cue the right behavior?
+
+- Each compressed bullet still triggers a recognizable agent action
+- Score-1 / Score-5 anchors paired (or both removed; never one without the other)
+- Examples retained where they were the only signal for a category
+- Pointers to full references (`Read references/X.md`) still valid paths
+
+**Concerns flag:** asymmetric removal (kept fail cues, lost success cues), example removal that leaves a category unanchored, a pointer to a renamed/moved file.
+
+## 6. Quality standards preservation
+
+Explicit must-haves still present?
+
+- Final-gate checklists (4 states, accessibility, responsive, etc.)
+- Output quality bars (line targets, "every X needs Y" rules)
+- Cross-cutting requirements (no Lorem Ipsum, real copy, etc.)
+
+**Concerns flag:** a quality bar dropped silently, a checklist item lost.
+
+---
+
+## Verdict definitions
+
+- **PASS** — All 6 dimensions PASS. The change is a net improvement; merge with confidence.
+- **CONCERNS** — One or more dimensions flagged but with surgical restoration possible. Specify the exact text to restore (typically a single bullet, sentence, or rubric anchor). Recommendation: apply restoration, then merge.
+- **FAIL** — Substantive content lost that can't be quickly restored. Revert the affected section before merging. Note: FAIL is rare — most "concerns" are restorable with a 1-2 line change.
+
+## Findings format
+
+For each non-PASS dimension:
+
+```
+**Dimension N: {name}**
+> Quoted BEFORE text that was lost
+Recommendation: restore as `{exact text to insert}` after line `{landmark}` in AFTER, OR leave (substance was redundant with X), OR discuss (judgment call).
+```
+
+## Net assessment
+
+One paragraph at the end of the report. Pattern: state the change's intent, whether it landed, and whether the agent's ability to do its job is preserved or improved. Be direct: "ship it", "ship after restoring X", "revert and redesign".

--- a/dev/skills/gspdev-eval-changes/rubric.md
+++ b/dev/skills/gspdev-eval-changes/rubric.md
@@ -1,8 +1,30 @@
 # Skill change evaluation rubric
 
-Six dimensions. Each scored **PASS / CONCERNS / FAIL**. Score against the AFTER file using BEFORE and the parent SKILL.md as context.
+Seven dimensions. Each scored **PASS / CONCERNS / FAIL**. Score against the AFTER file using BEFORE and the parent SKILL.md as context.
 
-## 1. Role + execution mode preservation
+**Order matters.** Intent achievement (Dimension 1) is scored FIRST — if the change didn't land its stated goal, the rest of the rubric is moot. Preservation dimensions (2-7) only matter if the intent was achieved.
+
+## 1. Intent achievement
+
+Did the change land its stated goal?
+
+The orchestrator passes the change's stated intent (from commit message, PR description, or user input) to every evaluator. Examples of intent:
+
+- "Trim file by 30-40%" → check actual delta vs target
+- "Extract X to a sibling for reuse" → check sibling is created correctly and referenced from AFTER
+- "Make agent more deterministic about Y" → check the new rule/cue actually constrains Y better than BEFORE
+- "Fix bug where agent does Z" → check the AFTER would no longer reproduce Z given the same input
+
+Score:
+- **PASS** — intent achieved cleanly; no obvious gap between goal and result
+- **CONCERNS** — intent partially achieved; specific gap (e.g., trim claimed -30%, actual -8%; or extraction left dangling references)
+- **FAIL** — intent not achieved or change works against the stated goal
+
+**Concerns flag:** delta below target, extraction incomplete, new rule still permits the bad behavior, side-effect changes that weren't part of the intent.
+
+If intent is unclear or absent: report "Intent not provided — skipping Dimension 1, scoring 2-7 as defensive eval only."
+
+## 2. Role + execution mode preservation
 
 Does the agent still know what it is and when to apply different modes?
 
@@ -12,7 +34,7 @@ Does the agent still know what it is and when to apply different modes?
 
 **Concerns flag:** mode disambiguation softened, role drift, lost handling for an input the parent skill still passes.
 
-## 2. Methodology completeness
+## 3. Methodology completeness
 
 Every numbered step / decision point / phase still present?
 
@@ -22,7 +44,7 @@ Every numbered step / decision point / phase still present?
 
 **Concerns flag:** a step removed, a conditional collapsed, an input/output left implicit.
 
-## 3. Constraints + rules preservation
+## 4. Constraints + rules preservation
 
 Are binding rules still binding?
 
@@ -33,7 +55,7 @@ Are binding rules still binding?
 
 **Concerns flag:** a constraint dropped, severity softened (must → should), validation gate weakened.
 
-## 4. Output specification clarity
+## 5. Output specification clarity
 
 Can the agent still produce the expected deliverables without ambiguity?
 
@@ -45,7 +67,7 @@ Can the agent still produce the expected deliverables without ambiguity?
 
 **Concerns flag:** a deliverable's structure became implicit, a path got vague, schema dropped without recoverable description.
 
-## 5. Distilled references actionable
+## 6. Distilled references actionable
 
 Compressed reference lists (HIG, anti-patterns, scoring rubrics) still cue the right behavior?
 
@@ -56,7 +78,7 @@ Compressed reference lists (HIG, anti-patterns, scoring rubrics) still cue the r
 
 **Concerns flag:** asymmetric removal (kept fail cues, lost success cues), example removal that leaves a category unanchored, a pointer to a renamed/moved file.
 
-## 6. Quality standards preservation
+## 7. Quality standards preservation
 
 Explicit must-haves still present?
 
@@ -70,9 +92,9 @@ Explicit must-haves still present?
 
 ## Verdict definitions
 
-- **PASS** — All 6 dimensions PASS. The change is a net improvement; merge with confidence.
+- **PASS** — All 7 dimensions PASS (or 6 PASS with Dimension 1 skipped due to no intent provided). The change is a net improvement; merge with confidence.
 - **CONCERNS** — One or more dimensions flagged but with surgical restoration possible. Specify the exact text to restore (typically a single bullet, sentence, or rubric anchor). Recommendation: apply restoration, then merge.
-- **FAIL** — Substantive content lost that can't be quickly restored. Revert the affected section before merging. Note: FAIL is rare — most "concerns" are restorable with a 1-2 line change.
+- **FAIL** — Either Dimension 1 is FAIL (intent not achieved), OR substantive content lost that can't be quickly restored. Revert the affected section before merging. Note: FAIL is rare for Dimensions 2-7 — most "concerns" are restorable with a 1-2 line change. Dimension 1 FAIL means redesigning the change itself.
 
 ## Findings format
 

--- a/dev/skills/gspdev-eval-changes/rubric.md
+++ b/dev/skills/gspdev-eval-changes/rubric.md
@@ -1,19 +1,27 @@
 # Skill change evaluation rubric
 
-Seven dimensions. Each scored **PASS / CONCERNS / FAIL**. Score against the AFTER file using BEFORE and the parent SKILL.md as context.
+Eight dimensions. Each scored **PASS / CONCERNS / FAIL / N/A**. Score against the AFTER file using BEFORE (if any) and the parent SKILL.md as context.
 
-**Order matters.** Intent achievement (Dimension 1) is scored FIRST — if the change didn't land its stated goal, the rest of the rubric is moot. Preservation dimensions (2-7) only matter if the intent was achieved.
+**Applies to any change** — additions, modifications, refactors, trims, rewrites.
 
-## 1. Intent achievement
+**For new files** (no BEFORE): score Dimensions 1-2 only. Mark Dimensions 3-8 as N/A — there's no prior state to regress against.
+
+**Order matters.** Intent dimensions (1 + 2) are scored FIRST — they answer "is this change worth shipping at all?" Preservation dimensions (3-8) only matter if both intents are coherent.
+
+Two distinct intents:
+- **Change intent** (Dimension 1) — what THIS PR/commit was trying to do
+- **Skill intent** (Dimension 2) — what the SKILL itself is supposed to do (per its frontmatter description + context + objective)
+
+## 1. Change intent achievement
 
 Did the change land its stated goal?
 
-The orchestrator passes the change's stated intent (from commit message, PR description, or user input) to every evaluator. Examples of intent:
+The orchestrator passes the change's stated intent (from PR description, commit message, or user input) to every evaluator. Examples:
 
 - "Trim file by 30-40%" → check actual delta vs target
 - "Extract X to a sibling for reuse" → check sibling is created correctly and referenced from AFTER
 - "Make agent more deterministic about Y" → check the new rule/cue actually constrains Y better than BEFORE
-- "Fix bug where agent does Z" → check the AFTER would no longer reproduce Z given the same input
+- "Fix bug where agent does Z" → check AFTER would no longer reproduce Z given the same input
 
 Score:
 - **PASS** — intent achieved cleanly; no obvious gap between goal and result
@@ -22,7 +30,40 @@ Score:
 
 **Concerns flag:** delta below target, extraction incomplete, new rule still permits the bad behavior, side-effect changes that weren't part of the intent.
 
-If intent is unclear or absent: report "Intent not provided — skipping Dimension 1, scoring 2-7 as defensive eval only."
+If intent is unclear or absent: report "Change intent not provided — skipping Dimension 1, scoring 2-8 as defensive eval only."
+
+## 2. Skill intent coherence
+
+Does the skill body (and any modified methodology/sibling) still deliver on what the SKILL.md frontmatter `description:` + `<context>` + `<objective>` promise?
+
+This is a **drift check** — separate from change intent. A change can land its goal (Dim 1 = PASS) but still drift the skill away from its stated purpose (Dim 2 = FAIL). Example: a perf trim that achieves -34% lines but accidentally drops a step that the description promised the skill performs.
+
+### Method
+
+**Step A — extract the skill's intent.** Read SKILL.md (parent or self):
+- `description:` (frontmatter) — one-line statement of purpose
+- `<context>` block — extended purpose, when to use, integration with pipeline
+- `<objective>` block — input → output contract, agent responsibilities
+
+Compose a one-sentence **skill intent statement** from these.
+
+**Step B — check coherence in AFTER.**
+- Does the AFTER file (or AFTER methodology + parent SKILL.md as a pair) deliver on the skill intent statement?
+- If the file under eval IS the SKILL.md itself: did the description/context/objective change? If yes, was the change intentional and does it match the body change? If no, did the body drift from the unchanged description?
+- If the file is methodology/sibling: parent SKILL.md description is unchanged — does the modified methodology still implement what the description promises?
+
+**Step C — check for drift across BEFORE → AFTER.**
+- BEFORE: was the skill already coherent? (If not, the issue predates the change — note it but don't blame the change.)
+- AFTER: did this change improve, preserve, or degrade coherence?
+
+Score:
+- **PASS** — AFTER body delivers on the skill intent; description/context/objective unchanged or coherently updated
+- **CONCERNS** — minor drift (e.g., description mentions a feature the body now treats as optional, or vice versa)
+- **FAIL** — significant drift (description promises X, body now does Y; or description was edited without matching body changes)
+
+**Concerns flag:** description references a removed step; body adds a major behavior absent from description; objective output contract no longer matches what AFTER produces; trigger phrases in description no longer match when the skill should fire.
+
+## 3. Role + execution mode preservation
 
 ## 2. Role + execution mode preservation
 
@@ -34,7 +75,7 @@ Does the agent still know what it is and when to apply different modes?
 
 **Concerns flag:** mode disambiguation softened, role drift, lost handling for an input the parent skill still passes.
 
-## 3. Methodology completeness
+## 4. Methodology completeness
 
 Every numbered step / decision point / phase still present?
 
@@ -44,7 +85,7 @@ Every numbered step / decision point / phase still present?
 
 **Concerns flag:** a step removed, a conditional collapsed, an input/output left implicit.
 
-## 4. Constraints + rules preservation
+## 5. Constraints + rules preservation
 
 Are binding rules still binding?
 
@@ -55,7 +96,7 @@ Are binding rules still binding?
 
 **Concerns flag:** a constraint dropped, severity softened (must → should), validation gate weakened.
 
-## 5. Output specification clarity
+## 6. Output specification clarity
 
 Can the agent still produce the expected deliverables without ambiguity?
 
@@ -67,7 +108,7 @@ Can the agent still produce the expected deliverables without ambiguity?
 
 **Concerns flag:** a deliverable's structure became implicit, a path got vague, schema dropped without recoverable description.
 
-## 6. Distilled references actionable
+## 7. Distilled references actionable
 
 Compressed reference lists (HIG, anti-patterns, scoring rubrics) still cue the right behavior?
 
@@ -78,7 +119,7 @@ Compressed reference lists (HIG, anti-patterns, scoring rubrics) still cue the r
 
 **Concerns flag:** asymmetric removal (kept fail cues, lost success cues), example removal that leaves a category unanchored, a pointer to a renamed/moved file.
 
-## 7. Quality standards preservation
+## 8. Quality standards preservation
 
 Explicit must-haves still present?
 
@@ -92,9 +133,16 @@ Explicit must-haves still present?
 
 ## Verdict definitions
 
-- **PASS** — All 7 dimensions PASS (or 6 PASS with Dimension 1 skipped due to no intent provided). The change is a net improvement; merge with confidence.
+- **PASS** — All 8 dimensions PASS (or 7 PASS with Dimension 1 skipped due to no change intent provided). The change is a net improvement; merge with confidence.
 - **CONCERNS** — One or more dimensions flagged but with surgical restoration possible. Specify the exact text to restore (typically a single bullet, sentence, or rubric anchor). Recommendation: apply restoration, then merge.
-- **FAIL** — Either Dimension 1 is FAIL (intent not achieved), OR substantive content lost that can't be quickly restored. Revert the affected section before merging. Note: FAIL is rare for Dimensions 2-7 — most "concerns" are restorable with a 1-2 line change. Dimension 1 FAIL means redesigning the change itself.
+- **FAIL** — Either Dimension 1 is FAIL (change intent not achieved), Dimension 2 is FAIL (skill drifted from its stated purpose), OR substantive content lost in 3-8 that can't be quickly restored. Revert the affected section before merging.
+
+**Distinct FAIL semantics:**
+- Dim 1 FAIL → redesign the change itself (intent unmet)
+- Dim 2 FAIL → align skill description ↔ body (either revert body or update description coherently)
+- Dims 3-8 FAIL → revert the cut that lost substance
+
+Most concerns are restorable with a 1-2 line change. FAIL is rare and consequential.
 
 ## Findings format
 


### PR DESCRIPTION
## Summary

New dev skill that consolidates the parallel-evaluator pattern used in PR #183 ([#85 methodology trim](https://github.com/jubscodes/get-shit-pretty/pull/183)).

`/gspdev-eval-changes` spawns one general-purpose evaluator agent per modified skill/agent/methodology file using a fixed **8-dimension rubric**: 2 intent dimensions + 6 preservation dimensions.

**Applies to any non-trivial change** — additions, modifications, refactors, trims, rewrites. Use before merging.

## Three gates, in order

1. **Change intent achieved?** Did the PR/commit land what it set out to do?
2. **Skill intent coherent?** Does the skill body deliver on its `description:` + `<context>` + `<objective>`? (Catches drift between frontmatter and body — a failure mode independent of change intent.)
3. **Substance preserved or improved?** Did the change avoid sacrificing what the agent needs?

A change can land its goal (Dim 1 PASS) but drift the skill (Dim 2 FAIL) by adding behavior the description doesn't reflect or removing a step the description promised. A coherent intent + description (Dims 1-2 PASS) can still break an output spec (Dim 6 FAIL). All three gates matter.

## How it works

1. Resolve scope — `$ARGUMENTS` commit range, default `main..HEAD` + uncommitted
2. Filter + classify into modified / new / deleted / trivial
3. Stage before/after copies
4. Identify parent SKILL.md per file
5. Load rubric
6. **Extract change intent** from PR description → commits → branch name → AskUserQuestion
7. **Extract skill intent** per file from SKILL.md `description` + `<context>` + `<objective>`
8. Spawn parallel evaluators (one Agent call per file, single message)
9. Aggregate verdicts
10. Surface concerns split by dimension type
11. Cleanup + final summary

## 8-dimension rubric

| # | Dimension | What it catches |
|---|---|---|
| **1** | **Change intent achievement** | trim claimed -30%, actual was -8%; extraction left dangling refs |
| **2** | **Skill intent coherence** | description promises X, body now does Y; SKILL.md description edited without matching body changes |
| 3 | Role + execution mode preservation | mode disambiguation softened, role drift |
| 4 | Methodology completeness | step removed, conditional collapsed |
| 5 | Constraints + rules preservation | constraint dropped, severity softened |
| 6 | Output specification clarity | deliverable structure became implicit |
| 7 | Distilled references actionable | asymmetric removal (kept fail cues, lost success cues) |
| 8 | Quality standards preservation | quality bar dropped silently |

Each dimension scored PASS / CONCERNS / FAIL / N/A. CONCERNS verdicts include surgical restoration recommendations.

## File-type handling

| Classification | Treatment |
|---|---|
| **modified** (BEFORE + AFTER) | Full 8-dimension eval |
| **new** (no BEFORE) | Dimensions 1-2 only; 3-8 marked N/A (no regression possible) |
| **deleted** (no AFTER) | Flagged for manual review (was description updated to match deletion?). Skipped from parallel eval |
| **trivial** (<30 lines, not SKILL.md) | Skipped |

## Files

| File | Lines | Purpose |
|---|---|---|
| `dev/skills/gspdev-eval-changes/SKILL.md` | 282 | Orchestrator |
| `dev/skills/gspdev-eval-changes/rubric.md` | 159 | Fixed 8-dimension rubric |
| `CLAUDE.md` | +1 line | Dev tools table entry |

## Differs from existing dev skills

- `/gspdev-audit` — static repo-wide checks (contracts, installer, version sync)
- `/gspdev-housekeeping` — drift detection (count mismatches, stale references)
- `/gspdev-prompt-audit` — semantic analysis of all skill prompts (whole-repo, slow)
- **`/gspdev-eval-changes`** — targeted intent + quality eval for a *specific* change (any type)

## Test plan

- [x] `bash dev/scripts/audit-tests.sh` — 70 pass / 0 fail / 2 unrelated warns
- [x] `node bin/install.js --claude --local` — symlinked 9 dev skills (was 8)
- [x] Skill discoverable as `/gspdev-eval-changes`
- [ ] Real-world test: invoke retrospectively on PR #183 to confirm both intent dimensions + preservation eval surface the right verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)