### PR TITLE
chore(critic-methodology): restore recognition bullet (eval-driven fix)

### DIFF
--- a/gsp/skills/gsp-project-critique/methodology/gsp-project-critic.md
+++ b/gsp/skills/gsp-project-critique/methodology/gsp-project-critic.md
@@ -101,6 +101,7 @@ Full scoring via `skills/gsp-project-critique/visual-taste.md` (15 items, X/75) 
 - Every score needs a specific example ("checkout flow scores 2 because...")
 - Fixes must be actionable ("Change X to Y", not "improve the thing")
 - Alternative directions should be genuinely different approaches
+- Balance criticism with recognition of what works well
 </methodology>
 
 <output>


### PR DESCRIPTION
## Summary

Surgical fix surfaced by `/gspdev-eval-changes` retrospective eval against PR #183 (the methodology trim).

The eval flagged Dimension 8 (Quality Standards preservation) as CONCERNS — the explicit \`- Balance criticism with recognition of what works well\` checklist item was dropped from the Quality Standards block. The principle survives in the \`<role>\` block and step 12, but the final-gate checklist item makes it easier to skip during scoring.

+1 line restored. File: 122 → 123L.

## Validation of the new eval skill

This PR is also a **proof point for `/gspdev-eval-changes`** (PR #184):

- The original PR #183 author missed this drop
- The original PR #183 review missed it (parallel evaluator agents at trim-time only flagged the Nielsen anchor issue)
- The retrospective eval against the merged state caught it on its first run

The eval skill is doing what it was designed to do.

## Related

- #185 — follow-up issue for the unfinished 30% target on critic.md (PR #183 only achieved 7.6%; eval flagged Dim 1 CONCERNS)
- #184 — \`/gspdev-eval-changes\` skill that surfaced this fix
- #183 — original methodology trim PR

## Test plan

- [x] Bullet restored verbatim from BEFORE
- [x] File still under all relevant token-budget thresholds
- [ ] (Optional) Re-run \`/gspdev-eval-changes\` against this branch to confirm Dim 8 now PASSes

🤖 Generated with [Claude Code](https://claude.com/claude-code)