### PR TITLE
refactor: fix 6 cross-skill path bugs across pipeline skills (#188)

### DIFF
--- a/gsp/skills/gsp-brand-research/SKILL.md
+++ b/gsp/skills/gsp-brand-research/SKILL.md
@@ -85,5 +85,5 @@ Update `{BRAND_PATH}/STATE.md`: set Phase 1 (Discover) to `complete`.
 
 ## Step 5: Phase transition
 
-Invoke `/gsp-phase-transition` with phase `discover` and output directory `{BRAND_PATH}/research/`.
+Invoke `/gsp-phase-transition` with phase `discover` and output directory `{BRAND_PATH}/discover/`.
 </process>

--- a/gsp/skills/gsp-project-build/methodology/gsp-project-builder.md
+++ b/gsp/skills/gsp-project-build/methodology/gsp-project-builder.md
@@ -187,7 +187,7 @@ These rules are always enforced for shadcn targets. They reflect the official sh
   ```
 - Do not override `--sidebar-width` in `globals.css` — it belongs on the provider instance
 
-Full reference: `references/anti-patterns.md` (available via Read for the complete list with fixes).
+Full reference: `${CLAUDE_SKILL_DIR}/../gsp-project-critique/anti-patterns.md` (available via Read for the complete list with fixes).
 
 **Theming reference:** when building or fixing themes, read `${CLAUDE_SKILL_DIR}/../../gsp-scaffold/shadcn-theming.md` — full token table, dark mode setup, common theming bugs and fixes.
 

--- a/gsp/skills/gsp-project-design/SKILL.md
+++ b/gsp/skills/gsp-project-design/SKILL.md
@@ -113,7 +113,7 @@ When `implementation_target` is not `figma`:
 
 ## Step 2.5: Load design references
 
-Read these reference files (relative to skill dir `${CLAUDE_SKILL_DIR}/../../references/`):
+Read these reference files (relative to skill dir `${CLAUDE_SKILL_DIR}/`):
 - `block-patterns.md`
 
 Hold their content for inlining into the agent prompt in Step 3.

--- a/gsp/skills/gsp-project-design/methodology/gsp-project-designer.md
+++ b/gsp/skills/gsp-project-design/methodology/gsp-project-designer.md
@@ -72,7 +72,7 @@ Baseline — **STYLE.md overrides** when present. Apply where the preset is sile
 - Accessibility: VoiceOver labels, `prefers-reduced-motion`, all 12 text sizes
 - Gestures: never override system back, long press = context menu
 
-Full reference: `skills/gsp-project-design/apple-hig-patterns.md` — Read for specific patterns.
+Full reference: `${CLAUDE_SKILL_DIR}/apple-hig-patterns.md` — Read for specific patterns.
 
 ## Anti-Pattern Awareness (distilled)
 
@@ -86,7 +86,7 @@ AI-convergence defaults to avoid — **STYLE.md takes precedence** when it expli
 - **Motion:** spring physics; `transform`+`opacity` only; 200-300ms min; `prefers-reduced-motion`; stagger entrances
 - **Components:** customize shadcn beyond defaults; skeleton not spinner; semantic HTML
 
-Full reference: `references/anti-patterns.md` — Read for fixes.
+Full reference: `${CLAUDE_SKILL_DIR}/../gsp-project-critique/anti-patterns.md` — Read for fixes.
 
 ## Quality Standards
 - Every screen needs all 4 states: default, empty, loading, error

--- a/gsp/skills/gsp-project-review/SKILL.md
+++ b/gsp/skills/gsp-project-review/SKILL.md
@@ -42,7 +42,7 @@ Read `{PROJECT_PATH}/brand.ref` → set `BRAND_PATH`.
 
 Read `{PROJECT_PATH}/config.json` to get `implementation_target`, `design_scope`, `codebase_type`.
 
-**Prior code accessibility audit:** Check if `{PROJECT_PATH}/review/accessibility-audit.md` exists from a prior `/gsp-accessibility --code` run. If yes, load it — the reviewer will reference these findings instead of performing inline a11y checks.
+**Prior code accessibility audit:** Check if `{PROJECT_PATH}/review/accessibility-audit.md` exists from a prior `/gsp-accessibility-audit --code` run. If yes, load it — the reviewer will reference these findings instead of performing inline a11y checks.
 
 ### Load all artifacts
 


### PR DESCRIPTION
## Summary

First PR of milestone #9 (Architecture refactor: pipeline ↔ expertise integration). Six surgical path-bug fixes surfaced by `/gspdev-eval-changes` cross-skill audit (2026-05-05).

## Fixes (6 × 1-line changes)

| # | File | Bug | Fix |
|---|---|---|---|
| 1 | `gsp-brand-research/SKILL.md:88` | phase-transition uses `{BRAND_PATH}/research/` but output is `discover/` | `discover/` |
| 2 | `gsp-project-design/methodology` line 75 | bare `skills/gsp-project-design/apple-hig-patterns.md` | `${CLAUDE_SKILL_DIR}/apple-hig-patterns.md` |
| 3 | `gsp-project-design/methodology` line 89 | `references/anti-patterns.md` doesn't exist there | `${CLAUDE_SKILL_DIR}/../gsp-project-critique/anti-patterns.md` |
| 4 | `gsp-project-design/SKILL.md` Step 2.5 | `${CLAUDE_SKILL_DIR}/../../references/block-patterns.md` (gsp/references/ is empty per CLAUDE.md) | `${CLAUDE_SKILL_DIR}/block-patterns.md` (actual location) |
| 5 | `gsp-project-review/SKILL.md:45` | `/gsp-accessibility --code` (wrong skill — `--code` belongs to audit skill) | `/gsp-accessibility-audit --code` |
| 6 | `gsp-project-build/methodology` line 190 | bare `references/anti-patterns.md` | `${CLAUDE_SKILL_DIR}/../gsp-project-critique/anti-patterns.md` |

## Test plan

- [x] `bash dev/scripts/audit-tests.sh` — 70 pass / 0 fail / 2 unrelated warns
- [x] All 6 referenced files verified to exist at the new path
- [x] Closes #188

## Related

- **Milestone #9**: Architecture refactor: pipeline ↔ expertise integration (12 issues)
- Surfaced by `/gspdev-eval-changes` (PR #184)
- Path-syntax linter to prevent recurrence: tracked in #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)