### PR TITLE
refactor: project pipeline expertise integration (#194-#197)

### DIFF
--- a/gsp/skills/gsp-project-critique/SKILL.md
+++ b/gsp/skills/gsp-project-critique/SKILL.md
@@ -69,10 +69,12 @@ Read `{PROJECT_PATH}/config.json` to get `implementation_target`, `design_scope`
 Read these reference files and hold their content for inlining into agent prompts in Step 2:
 - `${CLAUDE_SKILL_DIR}/../gsp-accessibility-audit/wcag-checklist.md`
 - `${CLAUDE_SKILL_DIR}/../gsp-color/references/color-composition.md`
+- `${CLAUDE_SKILL_DIR}/../gsp-typography/domains/scale.md` — type-scale verification rules
+- `${CLAUDE_SKILL_DIR}/../gsp-visuals/domains/imagery.md` — imagery vocabulary for critique
 - `${CLAUDE_SKILL_DIR}/../gsp-accessibility-audit/methodology/gsp-accessibility-auditor.md`
 - `${CLAUDE_SKILL_DIR}/../../templates/phases/critique.md` — critique output template
 
-> **Note:** Nielsen's heuristics, visual taste, and anti-patterns are distilled into the `gsp-project-critic` agent prompt. Full refs remain on disk for edge-case agent lookup.
+> **Note:** Nielsen's heuristics, visual taste, and anti-patterns are distilled into the `gsp-project-critic` agent prompt. anti-patterns.md is a critic-owned consolidated checklist; canonical sources are gsp-typography, gsp-color, gsp-visuals — update those when fixing drift, not the consolidated checklist alone.
 
 ## Step 1.9: Load agent methodology
 
@@ -92,6 +94,8 @@ Read `${CLAUDE_SKILL_DIR}/methodology/gsp-project-critic.md`. Include the full c
 - **Content of** research recommendations.md (loaded in Step 1)
 - **Content of** BRIEF.md
 - **Content of** color composition reference (loaded in Step 1.8)
+- **Content of** typography scale reference (loaded in Step 1.8)
+- **Content of** imagery vocabulary reference (loaded in Step 1.8)
 - **Content of** critique output template (loaded in Step 1.8)
 - `references_path`: `${CLAUDE_SKILL_DIR}/` — for supplementary Read access to visual-taste.md, anti-patterns.md
 - Output path: `{PROJECT_PATH}/critique/`

--- a/gsp/skills/gsp-project-critique/methodology/gsp-project-critic.md
+++ b/gsp/skills/gsp-project-critique/methodology/gsp-project-critic.md
@@ -84,11 +84,11 @@ The gap between "correct" and "good":
 - **Craft in details** — tinted shadows, spacing rhythm, hierarchy via weight+color+spacing not just size
 - **Distinctiveness** — would someone ask "who designed this?"
 
-Full scoring via `skills/gsp-project-critique/visual-taste.md` (15 items, X/75) — Read for a formal taste score.
+Full scoring via `${CLAUDE_SKILL_DIR}/visual-taste.md` (15 items, X/75) — Read for a formal taste score.
 
 ### Supplementary (Read from disk when needed)
 
-8. **Full anti-pattern scan** — Read `skills/gsp-project-critique/anti-patterns.md` for typography, color, and code quality patterns beyond the core checks above.
+8. **Full anti-pattern scan** — Read `${CLAUDE_SKILL_DIR}/anti-patterns.md` for typography, color, and code quality patterns beyond the core checks above (consolidated index; canonical sources are gsp-typography, gsp-color, gsp-visuals).
 9. **Color composition** — Evaluate palette strategy using the inlined color-composition reference (60-30-10 rule, monochrome vs accent, warm/cool consistency).
 
 ### Synthesis

--- a/gsp/skills/gsp-project-design/methodology/gsp-project-designer.md
+++ b/gsp/skills/gsp-project-design/methodology/gsp-project-designer.md
@@ -31,10 +31,10 @@ Every screen must reference specific techniques by name ("lift-shadow on feature
 1. **Define personas** — From BRIEF.md audience, create primary persona with goals and pain points
 2. **Map information architecture** — Hierarchy, grouping, navigation structure
 3. **Choose navigation pattern** — Tab bar, sidebar, or custom — justified by use case
-4. **Design core screens** — Each with wireframe description, component usage, interactions, and all states. Apply brand patterns and effects in every screen — not as a separate pass, but as the default visual language.
-5. **Specify accessibility** — WCAG compliance, VoiceOver order, Dynamic Type behavior
+4. **Design core screens** — Each with wireframe description, component usage, interactions, and all states. Apply brand patterns and effects in every screen — not as a separate pass, but as the default visual language. For color decisions, consult `${CLAUDE_SKILL_DIR}/../gsp-color/domains/system.md` for semantic mapping; for type, consult `${CLAUDE_SKILL_DIR}/../gsp-typography/domains/scale.md`.
+5. **Specify accessibility** — WCAG compliance, VoiceOver order, Dynamic Type behavior. Follow `${CLAUDE_SKILL_DIR}/../gsp-accessibility/SKILL.md` methodology when annotating screen states; `gsp-project-critique` will run an `/gsp-accessibility-audit` pass against this output downstream.
 6. **Define micro-interactions** — Only use techniques from the effects vocabulary. Reference them by name.
-7. **Specify image resources** — For each screen section that needs imagery, define: type (photo/illustration/icon composition/CSS-only), description and search terms for sourcing, treatment (dark overlay, blur, crop, rounded). Match the brand's imagery style from `imagery-style.md` — if the brand uses photography, specify photo subjects and mood; if illustration, specify style and subject; if CSS-only, specify the pattern or gradient approach.
+7. **Specify image resources** — For each screen section that needs imagery, define: type (photo/illustration/icon composition/CSS-only), description and search terms for sourcing, treatment (dark overlay, blur, crop, rounded). Match the brand's imagery style from `imagery-style.md`; consult `${CLAUDE_SKILL_DIR}/../gsp-visuals/domains/imagery.md` for canonical imagery vocabulary.
 8. **Build component plan** — When existing components inventory is provided, annotate which components to reuse, refactor, or create new
 
 ### Step 9: Brand fidelity self-check
@@ -56,6 +56,7 @@ Classify user feedback during design:
 
 On style-level feedback, ask via `AskUserQuestion`:
 - **Update brand style** — run `/gsp-brand-refine {feedback}` to update `.yml`/STYLE.md, then revise affected screens.
+- **Update style preset** — run `/gsp-style {preset} --enrich` if the feedback maps to preset-level techniques (patterns, constraints, effects vocabulary).
 - **Just this screen** — apply as a one-off.
 
 Style signals = anything mapping to `.yml` intensity/patterns/constraints/effects (radius, shadow, palette, motion, typography weight, layout archetype, surface treatment).

--- a/gsp/skills/gsp-project-research/SKILL.md
+++ b/gsp/skills/gsp-project-research/SKILL.md
@@ -57,6 +57,16 @@ Read `{BRAND_PATH}/patterns/INDEX.md`. If it exists, load foundation chunks (to 
 
 Read `{BRAND_PATH}/discover/INDEX.md`. If it exists, load `competitive-audit.md` and `trend-analysis.md` (to avoid duplicating brand-level research).
 
+### Brand strategy voice (for content-strategy chunk)
+
+Read `{BRAND_PATH}/strategy/voice-and-tone.md` and `{BRAND_PATH}/strategy/messaging.md` (if exists). The content-strategy chunk derives microcopy/tone direction from brand strategy — never invent voice in isolation.
+
+### Expertise references (load on demand for chunks below)
+
+The researcher's chunks should consult the canonical owners rather than re-deriving rules:
+- `accessibility-patterns.md` — read `${CLAUDE_SKILL_DIR}/../gsp-accessibility/SKILL.md` for WCAG criteria framing; do not duplicate WCAG specifics
+- `technical-research.md` — read `${CLAUDE_SKILL_DIR}/../gsp-style/styles/INDEX.yml` to align stack-specific token wiring with available presets
+
 ### Custom references
 
 If `{PROJECT_PATH}/references/INDEX.md` exists, load relevant references (competitor screenshots, brand guidelines, design specs). Pass to the researcher agent for context.
@@ -79,6 +89,8 @@ Read:
 
 If competitor URLs or reference sites are mentioned in BRIEF.md or `{PROJECT_PATH}/references/`, use `WebFetch` with `run_in_background: true` to pre-fetch them. This warms content for the researcher agent.
 
+**Caps:** max 5 competitor URLs per project, max 3 doc URLs per technical area. Pre-fetched content is inlined into the agent prompt — the agent does not run open-ended WebSearch during execution.
+
 ## Step 2: Spawn project researcher
 
 ### Load agent methodology
@@ -90,6 +102,7 @@ Pass in the agent prompt:
 - **Content of** brief scope chunks: scope.md, target-adaptations.md (loaded in Step 1)
 - **Content of** brand patterns foundation chunks (loaded in Step 1)
 - **Content of** brand discovery chunks: competitive-audit.md, trend-analysis.md (loaded in Step 1)
+- **Content of** brand strategy: voice-and-tone.md, messaging.md (loaded in Step 1) — drives content-strategy chunk; never invent voice
 - **Content of** custom references (loaded in Step 1)
 - **Content of** BRIEF.md (loaded in Step 1)
 - Any pre-fetched reference content (from Step 1.75)

--- a/gsp/skills/gsp-project-review/methodology/gsp-project-reviewer.md
+++ b/gsp/skills/gsp-project-review/methodology/gsp-project-reviewer.md
@@ -22,11 +22,12 @@ Cross-reference these against design specs to validate the implementation.
 3. **Run `git diff`** — see what actually changed, catch anything BUILD-LOG.md missed
 4. **Screen coverage** — compare designed screens against implemented screens in the codebase
 5. **Component coverage** — compare designed components against implemented components
-6. **Token audit** — Grep codebase for hardcoded color values, magic numbers, missing token references
-7. **Accessibility compliance** — Grep for ARIA attributes, check keyboard handlers, verify focus management
+6. **Token audit** — defer to canonical token rules at `${CLAUDE_SKILL_DIR}/../gsp-color/domains/system.md`; verify against `${CLAUDE_SKILL_DIR}/../gsp-style/style-preset-schema.md` for preset adherence. Flag hardcoded values, magic numbers, missing token references
+7. **Accessibility compliance** — invoke `/gsp-accessibility-audit --code` (via the orchestrator) instead of inline ARIA/keyboard Grep heuristics. Reference `${CLAUDE_SKILL_DIR}/../gsp-accessibility-audit/wcag-checklist.md` for code-mode criteria
 8. **Responsive verification** — confirm breakpoint behavior matches design intent
-9. **Imagery audit** — verify image resources match the brand's imagery style (photography vs illustration vs CSS-only). Check for generic gray placeholders or mismatched imagery types
-10. **Design fidelity** — overall assessment of how faithfully the build represents the design
+9. **Imagery audit** — verify image resources match brand's imagery style; consult `${CLAUDE_SKILL_DIR}/../gsp-visuals/domains/imagery.md` for canonical vocabulary. Check for generic gray placeholders or mismatched imagery types
+10. **Typography verification** — verify type scale + pairing against `${CLAUDE_SKILL_DIR}/../gsp-typography/domains/scale.md` and `pairing.md`
+11. **Design fidelity** — overall assessment of how faithfully the build represents the design
 
 ## Quality Standards
 - Issues must reference actual codebase file paths and line numbers (not `.design/build/` paths)


### PR DESCRIPTION
## Summary

P1/M cluster from milestone #9. Closes 4 issues. Adds expertise-skill cross-references to four pipeline skills that were previously expertise-thin per the `/gspdev-eval-changes` audit.

| Issue | Skill | Key changes |
|---|---|---|
| **#194** | project-design | Methodology pointers to gsp-color, gsp-typography, gsp-visuals, gsp-accessibility; style-feedback now routes to /gsp-style for preset-level changes |
| **#195** | project-research | Brand voice load (voice-and-tone.md + messaging.md); expertise pointers for accessibility-patterns + technical-research; web-fetch caps |
| **#196** | project-critique | Step 1.8 adds typography-scale + imagery-vocabulary; anti-patterns.md gets canonical-sources framing; path syntax normalized |
| **#197** | project-review | Token QA defers to gsp-color + gsp-style; a11y invokes `/gsp-accessibility-audit --code` instead of inline Grep; new typography-verification step |

Net: +29L / −10L across 5 files (the additions are surgical pointers, not duplicated content).

## Why this matters

The `/gspdev-eval-changes` audit found 7 of 10 pipeline skills CONCERNS or FAIL on Dim A (expertise usage). This PR addresses 4 of them. After merge: only project-build (#193) remains FAIL, and that's tracked separately as the largest refactor (P1/L, contributes to #87).

## Test plan

- [x] `bash dev/scripts/audit-tests.sh` — 70 pass / 0 fail / 2 unrelated warns
- [x] All cross-skill paths verified to resolve
- [x] Closes #194, #195, #196, #197

## Related

- **Milestone #9**: Architecture refactor: pipeline ↔ expertise integration
- Surfaced by `/gspdev-eval-changes` (PR #184)
- #193 (project-build) tracked separately as the heaviest refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)