### PR TITLE
refactor: resolve gsp-icons vs gsp-visuals icon-library duplication (#192)

### DIFF
--- a/gsp/skills/gsp-brand-identity/SKILL.md
+++ b/gsp/skills/gsp-brand-identity/SKILL.md
@@ -109,14 +109,15 @@ The agent writes 5 chunks + INDEX.md (creative decisions only — no technical e
 
 ## Step 3.5: Enrich with domain skills (parallel)
 
-After the creative-director finishes, invoke all 4 domain skills in parallel — they operate on separate chunks with zero dependencies:
+After the creative-director finishes, invoke all 5 domain skills in parallel — they operate on separate chunks with zero dependencies:
 
 - **`/gsp-logo --enrich`** — reads `logo-directions.md`, enriches with construction geometry, variation specs, clear space rules, minimum size calculations.
 - **`/gsp-color --enrich`** — reads `color-system.md`, generates OKLCH palettes via tints.dev, calculates WCAG contrast, writes `palettes.json`, enriches with contrast ratios and semantic mapping.
 - **`/gsp-typography --enrich`** — reads `typography.md`, generates mathematical type scale, adds fluid type formulas, enriches with font loading instructions.
-- **`/gsp-visuals --imagery --enrich`** — reads `imagery-style.md`, adds icon library specifics, CSS texture/treatment recipes, enriches with technical implementation details.
+- **`/gsp-visuals --imagery --enrich`** — reads `imagery-style.md`, enriches with photography/illustration direction, CSS texture/treatment recipes, image processing implementation. Icons are NOT covered here — `gsp-icons` owns them.
+- **`/gsp-icons --enrich`** — defines the icon system: library selection, stroke standardization, size system, container treatments, custom SVG direction.
 
-Invoke all 4 using the Skill tool simultaneously. Each skill loads its own domain references on-demand — no upfront context cost.
+Invoke all 5 using the Skill tool simultaneously. Each skill loads its own domain references on-demand — no upfront context cost.
 
 ## Step 4: Perspective check
 

--- a/gsp/skills/gsp-visuals/domains/imagery.md
+++ b/gsp/skills/gsp-visuals/domains/imagery.md
@@ -4,21 +4,21 @@
 
 ## Role
 
-You are a GSP imagery director. You define the visual language beyond color and type — photography style, illustration approach, iconography system, and image treatment recipes.
+You are a GSP imagery director. You define the visual language beyond color and type — photography style, illustration approach, and image treatment recipes. Iconography is owned by `gsp-icons` (the dedicated specialist); reference it but don't re-derive icon-system rules here.
 
-Imagery is the third pillar of visual identity alongside color and typography. It defines what things LOOK like — not token values, but visual direction that guides photo selection, illustration commissioning, icon usage, and image processing in code.
+Imagery is the third pillar of visual identity alongside color and typography. It defines what things LOOK like — not token values, but visual direction that guides photo selection, illustration commissioning, and image processing in code.
 
 ## Rules
 
 - Every imagery decision must connect to brand personality — "We use X because the brand is Y"
 - Provide concrete, actionable direction — not "use good photos" but "candid, desaturated, warm tone, eye-level, natural light"
 - Include anti-patterns — what to avoid is as important as what to use
-- Icon recommendations must name specific libraries with import paths
+- Icon system is owned by `gsp-icons` — point to it; don't duplicate library specs here
 
 ## Enrich mode (`--enrich`)
 
 Read existing `{BRAND_PATH}/identity/imagery-style.md`. Enrich with:
-- Specific icon library recommendation (npm package + import path) based on brand personality
+- (Icon library recommendations come from `/gsp-icons` — invoked separately in identity Step 3.5)
 - CSS treatment recipes (overlay gradients, masks, blend modes)
 - Texture CSS recipes (noise SVG, halftone, grid patterns) from brand `.yml` surfaces
 - Responsive image specs (aspect ratios, object-fit, art direction breakpoints)
@@ -65,16 +65,10 @@ Define these four domains:
 - **When to use:** hero sections, empty states, onboarding, error pages
 
 ### Iconography
-- **Library:** recommend a specific icon library with reasoning:
-  - `lucide-react` — clean, consistent, 1000+ icons, MIT license
-  - `@phosphor-icons/react` — 6 weights (thin->fill), 1500+ icons
-  - `@radix-ui/react-icons` — 15x15 grid, minimal, Radix ecosystem
-  - `@heroicons/react` — Tailwind ecosystem, 20/24px, outline/solid
-  - Custom SVG — when brand needs unique iconography
-- **Weight/stroke:** specific stroke width (1.5px, 2px, etc.)
-- **Size system:** icon sizes and their use cases (16px nav, 20px inline, 24px feature, 32px hero)
-- **Container treatment:** bare, in circle, in rounded square, with background tint
-- **Color:** monochrome (foreground), brand-tinted, multi-color
+
+Icon-system specifics (library selection, stroke weight, size system, container treatments, custom SVG direction) are owned by **`gsp-icons`** — the dedicated specialist. Invoke `/gsp-icons --enrich` from brand-identity Step 3.5 alongside this skill.
+
+For imagery, only flag icon usage in passing — e.g., "Empty states use illustrations, not icons" — without re-deriving library/weight/size rules.
 
 ### Textures & Patterns
 - **Surface treatment:** the brand's signature texture (noise grain, halftone dots, grid lines, scanlines, paper grain, none)
@@ -108,7 +102,7 @@ Define these four domains:
 {style, complexity, palette, stroke, when to use}
 
 ## Iconography
-{library + import, weight, size system, container, color}
+{owned by gsp-icons — see /gsp-icons --enrich output in icon-system.md}
 
 ## Textures & Patterns
 {surface treatment, CSS implementation, opacity + blend, placement, pattern motifs, gradient style}
@@ -133,8 +127,8 @@ Define these four domains:
 
     photography    {style} — {treatment}
     illustration   {style} — {when used}
-    icons          {library} — {weight}
     treatments     {key technique}
+    (icons         owned by /gsp-icons)
 ```
 
 ## Completion options


### PR DESCRIPTION
## Summary

Per `/gspdev-eval-changes` audit, both `gsp-icons` and `gsp-visuals/domains/imagery.md` owned icon-library knowledge — an architecture violation of CLAUDE.md's "never duplicate domain knowledge" rule.

**Decision: keep `gsp-icons` as the specialist.** It has more depth (library selection, stroke standardization, size system, container treatments, custom SVG direction). Strip icon coverage from `gsp-visuals/domains/imagery.md` and add `/gsp-icons` to brand-identity's parallel `--enrich` fan-out.

## Changes

**`gsp-visuals/domains/imagery.md`:**
- Removed the Iconography section (lines 67-77 detailed library/weight/size specs)
- Replaced with a single-paragraph pointer to `gsp-icons`
- Updated role, rules, enrich-mode, and output structure to reflect the new ownership boundary

**`gsp-brand-identity/SKILL.md` Step 3.5:**
- Added `/gsp-icons --enrich` as the 5th parallel call (was 4: logo, color, typography, visuals)
- The canonical fan-out now covers all visual identity dimensions via dedicated specialists

## After this

| Concern | Owner |
|---|---|
| Logo system | `gsp-logo` |
| Color system | `gsp-color` |
| Typography | `gsp-typography` |
| Imagery (photography, illustration, textures, treatments) | `gsp-visuals` |
| Icon system (library, weight, size, container, custom SVG) | `gsp-icons` |

No domain duplication. gsp-icons remains user-invocable for standalone runs; gsp-icons --enrich runs alongside the 4 existing enrich calls in identity Step 3.5.

## Test plan

- [x] `bash dev/scripts/audit-tests.sh` — 70 pass / 0 fail / 2 unrelated warns
- [x] `grep "enrich" gsp/skills/gsp-brand-identity/SKILL.md | wc -l` → 5 (was 4)
- [x] No remaining icon library/weight/size specs in gsp-visuals/domains/imagery.md
- [x] Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)