### PR TITLE
feat: gsp-accessibility --validate + brand-guidelines WCAG gate (#191)

### DIFF
--- a/gsp/skills/gsp-accessibility/SKILL.md
+++ b/gsp/skills/gsp-accessibility/SKILL.md
@@ -46,6 +46,7 @@ Read `$ARGUMENTS` to determine the mode:
 |-------|------|--------|
 | `--check #FG #BG` | Quick contrast check | Display only |
 | `--tokens` | Token-only: contrast pairs, sizing, spacing | `critique/accessibility-token-audit.md` |
+| `--validate <yml-path>` | Pre-emit gate: validate a brand `.yml` for WCAG compliance | Exit 0 (pass) / exit 1 (fail) — failures to stdout, no file writes |
 | (no args) | Mode picker | Prompt user |
 
 Additional flag: `--level AAA` overrides conformance level (default: AA).
@@ -70,6 +71,10 @@ If args contain `--check`, extract the two hex color values and skip to Step 3.
 ### Token audit mode (`--tokens`)
 
 Skip to Step 4.
+
+### Validate mode (`--validate <yml-path>`)
+
+Skip to Step 4.5.
 
 ## Step 3: Quick check mode (`--check #FG #BG`)
 
@@ -204,6 +209,51 @@ Display result and use `AskUserQuestion`:
 - **Run full design audit** — "run `/gsp-accessibility-audit` for full WCAG design audit"
 - **Run code audit** — "run `/gsp-accessibility-audit --code` to check the codebase"
 - **Done** — "that's all for now"
+
+## Step 4.5: Validate mode (`--validate <yml-path>`)
+
+Pre-emit gate for `gsp-brand-guidelines` (and any caller that needs a yes/no contrast verdict on a brand `.yml` without project context).
+
+**Differs from `--tokens`:** no project resolution, no file writes, returns exit code instead of writing a chunk. Use when you need a hard PASS/FAIL gate before downstream emission.
+
+### Inputs
+
+- `<yml-path>` — absolute or relative path to a brand `.yml` preset (e.g. `.design/branding/{brand}/patterns/{brand-name}.yml`)
+- `--level AA|AAA` — optional conformance override (default: AA)
+
+### Checks (subset of `--tokens`, contrast-only)
+
+Reuse the contrast logic from Step 4 (sections 4.1, 4.2, 4.3):
+
+1. **Contrast pairs** — every semantic foreground/background pair from the `.yml`. Flag failures: normal text < 4.5:1 (AA) or < 7:1 (AAA), large text < 3:1 (AA) or < 4.5:1 (AAA), non-text < 3:1
+2. **Interactive states** — hover/active/focus/disabled pairs. Disabled states still need 3:1 non-text contrast
+3. **Focus ring** — `--ring` token vs adjacent backgrounds, ≥ 3:1
+4. **Dark mode** — if `dark_mode.color` exists, re-verify all pairs
+
+Skip the `--tokens` extras (touch targets, typography minimums) — those are not contrast gates.
+
+### Output
+
+**On pass** — print one line to stdout, exit 0:
+
+```
+✓ /gsp-accessibility --validate {yml-name} — N pairs checked, all WCAG 2.2 {level} compliant
+```
+
+**On fail** — print failing pairs + exit 1:
+
+```
+✗ /gsp-accessibility --validate {yml-name} — {M} contrast failure(s) (WCAG 2.2 {level})
+
+  Failures:
+    {token-pair}      ratio {N.N}:1   required {required}:1   ({use-case})
+    {token-pair}      ratio {N.N}:1   required {required}:1   ({use-case})
+    ...
+
+  Fix via: /gsp-brand-refine "{token-name} contrast"
+```
+
+**No file writes.** This mode is a callable gate — output goes to stdout, exit code carries the verdict. Stop here; no AskUserQuestion routing.
 
 ## Step 5: Update STATE.md
 

--- a/gsp/skills/gsp-brand-guidelines/SKILL.md
+++ b/gsp/skills/gsp-brand-guidelines/SKILL.md
@@ -216,6 +216,15 @@ Spawn the `gsp-brand-engineer` agent with (reuse **Agent methodology** loaded in
 >
 > The `.yml` and `STYLE.md` are confirmed — do not modify them. Focus on mapping tokens to the detected component library and specifying overrides.
 
+## Step 4.7: WCAG validation gate
+
+Before emitting `theme.json` (the artifact that installs into real codebases), validate the assembled `.yml` against WCAG 2.2 AA contrast requirements. Inaccessible token pairs must not ship to production.
+
+Invoke `/gsp-accessibility --validate {BRAND_PATH}/patterns/{brand-name}.yml` (use `--level AAA` if `accessibility_level` in the project config is set to AAA).
+
+- **Pass (exit 0):** continue to Step 4.75
+- **Fail (exit 1):** STOP. The skill prints failing token pairs + the recommended fix path. Surface the failures to the user with: `Theme emission blocked — {N} contrast failure(s). Run /gsp-brand-refine to fix the failing pairs, then re-run /gsp-brand-guidelines.` Do NOT emit theme.json. The pipeline is incomplete until validation passes
+
 ## Step 4.75: Emit shadcn theme registry artifact
 
 Generate `{brand-name}.theme.json` (registry:theme) alongside the existing patterns. This is the artifact `/gsp-brand-apply` installs into shadcn codebases.


### PR DESCRIPTION
## Summary

Closes #191 — adds the WCAG validation gate the brand pipeline was missing. Two-step delivery: (1) new mode in gsp-accessibility, (2) wire the gate in brand-guidelines.

## Step 1 — `gsp-accessibility --validate <yml>` mode

New callable gate that takes a brand `.yml` directly (no project context required), runs contrast-only checks, returns exit 0 (pass) / exit 1 (fail).

Differs from existing modes:

| Mode | Project context? | File writes? | Use case |
|---|---|---|---|
| `--check #FG #BG` | No | No | Single-pair contrast spot-check |
| `--tokens` | Yes (PROJECT_PATH) | Yes (`critique/accessibility-token-audit.md`) | Project critique phase |
| **`--validate <yml>`** | **No** | **No (exit code only)** | **Pre-emit gate before theme.json ships** |

Reuses the contrast logic from `--tokens` Step 4 (sections 4.1, 4.2, 4.3) — pairs, interactive states, focus ring, dark mode. Skips the `--tokens` extras (touch targets, typography minimums) since those aren't contrast gates.

Output on fail surfaces failing pairs with the recommended fix path:

```
✗ /gsp-accessibility --validate {yml-name} — {M} contrast failure(s)

  Failures:
    {token-pair}      ratio {N}:1   required {required}:1   ({use-case})
    ...

  Fix via: /gsp-brand-refine "{token-name} contrast"
```

## Step 2 — `gsp-brand-guidelines` Step 4.7 WCAG gate

Inserted between Step 4 (`.yml` emission) and Step 4.75 (`.theme.json` emission).

- Invokes `/gsp-accessibility --validate {BRAND_PATH}/patterns/{brand-name}.yml`
- Uses `--level AAA` when `accessibility_level` in the project config is set to AAA
- **Pass (exit 0)** → continue to Step 4.75 (theme.json emission)
- **Fail (exit 1)** → STOP. Surface failing pairs + route user to `/gsp-brand-refine`. Pipeline is incomplete until validation passes

The artifact `/gsp-brand-apply` installs into shadcn codebases now cannot carry inaccessible token pairs to production.

## Test plan

- [x] `bash dev/scripts/audit-tests.sh` — 70 pass / 0 fail / 2 unrelated warns
- [x] gsp-accessibility/SKILL.md updated: new mode in parse table + new Step 4.5
- [x] gsp-brand-guidelines/SKILL.md updated: new Step 4.7 between Step 4 and Step 4.75
- [x] Closes #191

## Related

- **Milestone #9**: Architecture refactor: pipeline ↔ expertise integration — last open issue
- After this lands: milestone #9 closes (12 of 12 issues complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)