### PR TITLE
harness(w1): split CLAUDE.md procedures, add MEMORY.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Published as `get-shit-pretty` on npm. Use `/gspdev-publish` — it runs the aud
 
 ### Dependencies rule
 
-The npm package must have **zero production dependencies**. The installer (`bin/install.js`) and scripts use only Node.js builtins. All deps stay in `devDependencies`. Never add to `dependencies` — every `pnpm dlx get-shit-pretty` user would pull them in for no reason. Enforced by CI (W2a) and `PreToolUse` hook (W3).
+The npm package must have **zero production dependencies**. The installer (`bin/install.js`) and scripts use only Node.js builtins. All deps stay in `devDependencies`. Never add to `dependencies` — every `pnpm dlx get-shit-pretty` user would pull them in for no reason.
 
 ## Dev tools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,14 @@
 # GSP — Get Shit Pretty
 
+## Must-always / Must-never
+
+- **Always** edit source under `gsp/` — never inside `.claude/`, `.opencode/`, `.gemini/`, `.agents/`, `.codex/` (symlinks or installer-managed).
+- **Always** put new package dependencies in `devDependencies` — the npm package ships zero prod deps.
+- **Always** ship changes via PR — `main` is protected, no direct push. Squash-merge via `gh pr merge --squash`.
+- **Never** edit inside `.design/` from a skill — it's user/agent output only.
+- **Never** add `model:` or `effort:` to skill frontmatter — model selection is the user's choice.
+- **Never** hardcode output paths in agents — use `"path provided by the skill that spawned you"`.
+
 Design engineering system for Claude Code, OpenCode, Gemini, and Codex.
 
 ## Git workflow
@@ -112,74 +121,6 @@ To reinstall after adding/removing files: `node bin/install.js --claude --local`
 - Agent output paths must be dynamic: `"path provided by the skill that spawned you"` (no hardcoded `.design/` paths)
 - Skills resolve shared files via `${CLAUDE_SKILL_DIR}/../../` for templates, and `${CLAUDE_SKILL_DIR}/../gsp-{skill}/` for colocated references (see reference colocation rule)
 
-### Agent input inlining rule
-
-**Skills must inline all content when spawning agents.** The skill reads input files during validation/context steps — pass that content directly in the agent prompt. Never pass file paths and expect the agent to re-read them. Each agent Read turn costs 18-35s depending on model.
-
-Pattern: `- **Content of** {file} (loaded in Step N)` in the spawn instruction.
-
-Exceptions — agents that legitimately need to read from disk:
-- `gsp-project-builder` (screen agents) — reads live codebase foundations
-- `gsp-project-reviewer` — Grep/Glob on actual source files
-- `gsp-accessibility-auditor` (code mode) — Grep/Glob on source files
-
-### Claude Code context cost model
-
-Understanding what loads when is critical for keeping sessions lean. These costs apply to every conversation, not just GSP workflows.
-
-**Session start (always loaded, every conversation):**
-- `.claude/agents/*.md` — agent stubs (frontmatter + one-line body, ~12 lines each, ~130 lines total)
-- `.claude/references/*.md` — full file content of every reference file
-- Skill descriptions — the `description:` line from each SKILL.md (negligible)
-- `CLAUDE.md` files — project and user-level
-
-**Skill invocation (loaded on demand):**
-- Full SKILL.md body — only when the skill is triggered
-- `@` references in `<execution_context>` — resolved and inlined when the skill runs
-- Sibling files in skill directories — **inert** until explicitly Read by the skill
-
-**Agent spawn (loaded on demand):**
-- Agent stub is already in context from session start (just tool permissions + name)
-- Methodology loaded by the spawning skill from `methodology/gsp-{agent}.md` sibling file
-- Agent gets its own context window with the spawning skill's prompt + inlined methodology
-
-**Implications for GSP:**
-- **`gsp/references/` is empty — all references live in skill directories.** Domain knowledge is colocated with the expertise skill that owns it. Pipeline skills read from expertise skills via cross-skill paths. Nothing installs to `.claude/references/`.
-- **Agent stubs are lean, methodology lives in skills.** Agent `.md` files contain only frontmatter (tools, model, hooks) + a one-line body. Full methodology lives in `gsp/skills/{skill}/methodology/gsp-{agent}.md` and is read by the skill at spawn time. This keeps session-start cost minimal (~130 lines for 12 agents vs ~1,500 for full definitions).
-- **Skill sibling files are free until used.** A skill directory with 74 `.yml` presets costs zero at session start. Use this for reference material, examples, methodology, and templates that the skill reads on demand.
-- **Cross-skill references use relative paths:** `${CLAUDE_SKILL_DIR}/../gsp-other-skill/ref.md` — this reads the file on demand with zero session-start cost.
-
-### Reference colocation rule
-
-Reference files live inside the skill directory that is their primary consumer, not in a shared `references/` directory. This ensures:
-1. Zero session-start context cost (sibling files are inert)
-2. Skills are self-contained and portable (standalone capability)
-3. References load only when the consuming skill runs
-
-**Single-owner references** go directly into the primary skill's directory.
-
-**Shared references** (consumed by 2-4 skills) go into the primary consumer's directory. Other skills read them via `${CLAUDE_SKILL_DIR}/../gsp-primary-skill/ref.md`.
-
-**Ubiquitous references** (consumed by 5+ skills, e.g. `chunk-format.md`, `phase-transitions.md`) are duplicated into each consuming skill's directory as sibling files. This costs disk space but ensures every skill is self-contained and works on all runtimes (no loose files at the skills root).
-
-### Context optimization rules
-
-These rules minimize token waste across the pipeline. Enforced by audit tests C12, I19.
-
-**Model selection is the user's choice.** Skills do not declare `model:` or `effort:` in frontmatter — the user controls which model runs each phase. Pipeline creative/technical skills include a hint in their `description:` field (e.g., "benefits from capable models") as passive guidance. The installer still strips any `model:`/`effort:` fields for non-Claude runtimes (backwards compat for forks).
-
-**Context fork for pure dispatchers:** Pipeline skills that have zero interactive steps (no `AskUserQuestion` before agent spawn) must use `context: fork` in frontmatter. This isolates execution_context references from the main conversation window. Currently forked: `project-design`, `project-critique`, `project-review`. Never fork skills with interactive steps — test C12 enforces this.
-
-**Double-dispatch is intentional:** Forked skills use the Agent tool inside the fork to spawn executors. Do NOT collapse this with the `agent:` frontmatter field. The fork isolates the orchestrator; the Agent tool gives the executor a clean start. The orchestrator owns validation, routing, and state updates — the agent owns creative/technical execution.
-
-**Execution context is for orchestrator-consumed content only.** Reference files that the orchestrator only passes through to agents must NOT be in `<execution_context>`. Instead, add a "Load references" step before the spawn that reads them from disk. This keeps orchestrator Steps 0-2 (validation, prerequisites) lean. Only keep templates and references the orchestrator itself consumes in execution_context.
-
-**Templates loaded at write time.** Skills that write artifacts from templates (e.g., `gsp-start` writing BRIEF.md, STATE.md) must read templates at the point of writing, not in execution_context. Pattern: `Read templates from ${CLAUDE_SKILL_DIR}/../../templates/{path}/ and write artifacts`.
-
-**SubagentStop hooks for all chunk-producing agents.** Every agent that writes deliverable chunks must have a SubagentStop hook in `gsp/hooks/hooks.json` that verifies expected outputs exist. Covered: `gsp-project-designer`, `gsp-project-critic`, `gsp-brand-creative-director`, `gsp-brand-engineer`, `gsp-project-builder`, `gsp-project-reviewer`.
-
-**Filesystem is the integration layer.** Phases consume prior-phase output from disk (`.design/`), never from conversation context. Forked phases write STATE.md and artifact files to disk — these persist across fork boundaries. No phase should rely on conversation history for prior-phase artifacts.
-
 ## Key files
 
 - `bin/install.js` — multi-runtime installer (symlinks for local Claude, copies for global/other runtimes)
@@ -193,18 +134,11 @@ These rules minimize token waste across the pipeline. Enforced by audit tests C1
 
 ## npm publication
 
-Published as `get-shit-pretty` on npm. Before publishing:
-
-1. Ensure VERSION and package.json versions agree
-2. Run `bash dev/scripts/audit-tests.sh` — all tests must pass
-3. Update CHANGELOG.md with the new version section
-4. `npm publish`
-
-The `files` field in package.json controls what's included: `.mcp.json`, `bin`, `scripts`, `gsp`.
+Published as `get-shit-pretty` on npm. Use `/gspdev-publish` — it runs the audit suite, bumps versions, updates CHANGELOG, and prompts `npm publish`. Manual steps in `dev/skills/gspdev-publish/SKILL.md`.
 
 ### Dependencies rule
 
-The npm package must have **zero production dependencies**. The installer (`bin/install.js`) and scripts use only Node.js builtins. All deps (Next.js, React, shadcn, MDX, etc.) are for the local website (`src/`) and must stay in `devDependencies`. Never add a package to `dependencies` — it would be pulled in by every `pnpm dlx get-shit-pretty` (or `bunx`) user for no reason.
+The npm package must have **zero production dependencies**. The installer (`bin/install.js`) and scripts use only Node.js builtins. All deps stay in `devDependencies`. Never add to `dependencies` — every `pnpm dlx get-shit-pretty` user would pull them in for no reason. Enforced by CI (W2a) and `PreToolUse` hook (W3).
 
 ## Dev tools
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -12,7 +12,7 @@ Durable context for fresh Claude Code sessions working on GSP itself. Update whe
 - **v0.10.0** (2026-05-05) — current release. CHANGELOG.md has full notes.
 - **gsp-accessibility --validate** (#191/#208) — WCAG gate for brand-guidelines
 - **project-build SKILL.md trim** (#205/#207) — 538→450L via 4 sibling extractions
-- **harness improvements (audit 2026-06)** — see `docs/superpowers/specs/2026-06-05-gsp-harness-improvements-design.md`
+- **harness improvements (audit 2026-06)** — Wave 1 shipped (CLAUDE.md trim + nested CLAUDE.md + MEMORY.md). W2 (CI + ESLint) and W3 (PreToolUse hooks) follow.
 
 ## Open known issues
 
@@ -21,4 +21,4 @@ Durable context for fresh Claude Code sessions working on GSP itself. Update whe
 ## Tracking conventions
 
 - Inspiration links: append to issue #70
-- Harness audit: re-run `/harness-doctor` after each wave merges; expected post-W3 scorecard in the design doc
+- Harness audit: re-run `/harness-doctor` after each wave merges to track scorecard progress

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,24 @@
+# Project Memory
+
+Durable context for fresh Claude Code sessions working on GSP itself. Update when you ship something significant or close an umbrella issue.
+
+## Active umbrellas
+
+- **#83 — token budget perf.** Sub-issues #84–#87 closed. **#181, #182 still open.**
+- **#211 — planning theater.** Chunk-per-axis 7-8× planning-to-code ratio. Filed 2026-05-18. Next-frontier perf axis.
+
+## Recently shipped
+
+- **v0.10.0** (2026-05-05) — current release. CHANGELOG.md has full notes.
+- **gsp-accessibility --validate** (#191/#208) — WCAG gate for brand-guidelines
+- **project-build SKILL.md trim** (#205/#207) — 538→450L via 4 sibling extractions
+- **harness improvements (audit 2026-06)** — see `docs/superpowers/specs/2026-06-05-gsp-harness-improvements-design.md`
+
+## Open known issues
+
+- (track here as discovered)
+
+## Tracking conventions
+
+- Inspiration links: append to issue #70
+- Harness audit: re-run `/harness-doctor` after each wave merges; expected post-W3 scorecard in the design doc

--- a/gsp/CLAUDE.md
+++ b/gsp/CLAUDE.md
@@ -1,0 +1,37 @@
+# Working in `gsp/`
+
+This directory is the source of truth for all GSP skills, agents, hooks, prompts, and templates. The installer (`bin/install.js`) copies/symlinks from here into runtime dirs (`.claude/`, `.opencode/`, `.gemini/`, `.agents/`, `.codex/`). **Edit here, never in runtime dirs.**
+
+## Claude Code context cost model
+
+What loads when — critical for keeping sessions lean.
+
+**Session start (always loaded):**
+- `.claude/agents/*.md` — agent stubs (frontmatter + one-line body, ~130L total)
+- Skill `description:` lines (negligible)
+- Top-level `CLAUDE.md` + nested `CLAUDE.md` for the working subtree
+- User-level `~/.claude/CLAUDE.md`
+
+**Skill invocation (on demand):**
+- Full `SKILL.md` body
+- `@`-references in `<execution_context>` (resolved & inlined at invocation)
+- Sibling files (`domains/`, `references/`, `methodology/`) — inert until explicitly `Read`
+
+**Agent spawn (on demand):**
+- Agent stub already in context from session start
+- Methodology loaded by the spawning skill from `methodology/gsp-{agent}.md`
+- Agent gets its own context window
+
+**Implications:**
+- `gsp/references/` is empty — references live colocated with the owning skill
+- Agent stubs are lean (~12L each); methodology lives in skills
+- Skill sibling files are free until used — exploit this for large reference material
+- Cross-skill references use `${CLAUDE_SKILL_DIR}/../gsp-other-skill/ref.md`
+
+## Reference colocation rule
+
+Reference files live inside the skill directory that is their primary consumer, not in a shared `references/`. Ensures (1) zero session-start cost, (2) self-contained skills, (3) references load only when consuming skill runs.
+
+- **Single-owner references** → primary skill's directory
+- **Shared references** (2–4 consumers) → primary consumer's directory; others read via `${CLAUDE_SKILL_DIR}/../gsp-primary/ref.md`
+- **Ubiquitous references** (5+ consumers, e.g. `chunk-format.md`) → duplicated into each consumer (disk cost, but every skill works standalone on all runtimes)

--- a/gsp/agents/CLAUDE.md
+++ b/gsp/agents/CLAUDE.md
@@ -1,0 +1,13 @@
+# Authoring GSP agents
+
+Agent source of truth: `gsp/agents/gsp-{name}.md`. Never edit `.claude/agents/` directly — those are symlinks.
+
+## Lean stub convention
+
+Agent `.md` files contain frontmatter (tools, model, hooks) + a one-line body. **No full methodology in the stub** — it lives in `gsp/skills/{spawning-skill}/methodology/gsp-{agent}.md` and is read by the skill at spawn time.
+
+This keeps session-start cost minimal: ~130L for all 12 agent stubs vs. ~1,500L if methodology were inline. Every conversation pays the session-start cost.
+
+## Dynamic output paths
+
+Agent output paths must be dynamic: `"path provided by the skill that spawned you"`. No hardcoded `.design/` paths. This lets skills target arbitrary working directories.

--- a/gsp/skills/CLAUDE.md
+++ b/gsp/skills/CLAUDE.md
@@ -1,0 +1,30 @@
+# Authoring GSP skills
+
+## Agent input inlining rule
+
+**Skills must inline all content when spawning agents.** The skill reads input files during validation/context steps — pass that content directly in the agent prompt. Never pass file paths and expect the agent to re-read them. Each agent `Read` turn costs 18–35s.
+
+Pattern in the spawn instruction: `- **Content of** {file} (loaded in Step N)`.
+
+**Exceptions** — agents that legitimately read from disk:
+- `gsp-project-builder` (screen agents) — reads live codebase foundations
+- `gsp-project-reviewer` — Grep/Glob on actual source files
+- `gsp-accessibility-auditor` (code mode) — Grep/Glob on source files
+
+## Context optimization rules
+
+Enforced by audit tests C12, I19.
+
+**Model selection is the user's choice.** Skills do not declare `model:` or `effort:` in frontmatter. Pipeline creative/technical skills hint in their `description:` (e.g., "benefits from capable models"). The installer strips `model:`/`effort:` for non-Claude runtimes.
+
+**Context fork for pure dispatchers.** Pipeline skills with zero interactive steps (no `AskUserQuestion` before agent spawn) must use `context: fork` in frontmatter. Currently forked: `project-design`, `project-critique`, `project-review`. Never fork skills with interactive steps — test C12 enforces this.
+
+**Double-dispatch is intentional.** Forked skills use the `Agent` tool inside the fork to spawn executors. Do NOT collapse this with the `agent:` frontmatter field. The fork isolates the orchestrator; the `Agent` tool gives the executor a clean start.
+
+**Execution context is for orchestrator-consumed content only.** Reference files the orchestrator only passes through to agents must NOT be in `<execution_context>`. Add a "Load references" step before the spawn that reads them from disk.
+
+**Templates loaded at write time.** Skills that write artifacts from templates must read templates at the point of writing, not in `execution_context`. Pattern: `Read templates from ${CLAUDE_SKILL_DIR}/../../templates/{path}/ and write artifacts`.
+
+**SubagentStop hooks for all chunk-producing agents.** Every agent that writes deliverable chunks needs a `SubagentStop` hook in `gsp/hooks/hooks.json` verifying expected outputs exist. Covered: `gsp-project-designer`, `gsp-project-critic`, `gsp-brand-creative-director`, `gsp-brand-engineer`, `gsp-project-builder`, `gsp-project-reviewer`.
+
+**Filesystem is the integration layer.** Phases consume prior-phase output from disk (`.design/`), never from conversation context. Forked phases write STATE.md and artifact files to disk.


### PR DESCRIPTION
## Summary

First of three thematic waves closing harness gaps from the 2026-06-05 audit (Contract / Sensors / Enforcement). This PR addresses **Contract**.

- Trim top-level `CLAUDE.md` from **245 → 179 lines**
- Move procedures into nested `CLAUDE.md` files — auto-load when working in subtree per [Claude Code docs](https://code.claude.com/docs/en/memory):
  - `gsp/CLAUDE.md` — context cost model + reference colocation rule
  - `gsp/skills/CLAUDE.md` — agent inlining + context optimization rules
  - `gsp/agents/CLAUDE.md` — lean stub convention + dynamic output paths
- Add top-of-file **Must-always / Must-never** block (6 hard rules)
- Add project-level `MEMORY.md` — active umbrellas (#83, #211), recently shipped, tracking conventions
- Local-only: pruned `.claude/settings.local.json` of broad allows (`Bash(curl:*)`, `Bash(rm:*)`, `Bash(grep:*)`, `Bash(ls:*)`, loop fragments, `WebSearch`, hardcoded `wc -l` paths). These should move to `~/.claude/settings.json` if needed broadly. `.claude/` is gitignored — not committed here.

## Why nested `CLAUDE.md` and not `.claude/rules/`?

Claude Code does support `.claude/rules/*.md` with `paths:` frontmatter natively, but two open-and-closed-not-planned issues make it unreliable today: [#23478](https://github.com/anthropics/claude-code/issues/23478) (`paths:` rules don't fire on Write, only Read — misses guidance at skill creation time) and [#17204](https://github.com/anthropics/claude-code/issues/17204) (documented `paths:` YAML-list syntax fails silently; only undocumented `globs:` works). Revisit when those land.

## Test plan

- [x] `bash dev/scripts/audit-tests.sh` — 72 PASS / 2 pre-existing WARN / 0 FAIL (matches baseline)
- [x] `wc -l CLAUDE.md` reports ≤ 180 (actual: 179)
- [x] All four extracted `###` headings absent from `CLAUDE.md`
- [ ] Manual: start a fresh Claude Code session in `gsp/skills/` and verify the skill-authoring rules are loaded (`/memory` should show `gsp/skills/CLAUDE.md`)

## Follow-up waves

- **W2a** — CI workflow running audit-tests + zero-prod-deps check + build smoke
- **W2b** — ESLint flat config for `src/`
- **W3** — PreToolUse hooks blocking edits to symlinked runtime dirs + adding production deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)