### PR TITLE
harness(w2a): add CI for audit-tests, zero-prod-deps, build smoke

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,42 @@
+name: Harness Audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  audit-tests:
+    name: Audit suite (65 tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Run audit suite
+        run: bash dev/scripts/audit-tests.sh
+
+  zero-prod-deps:
+    name: Zero production dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Check
+        run: bash dev/scripts/check-zero-prod-deps.sh
+
+  build-smoke:
+    name: Next.js build smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,8 +11,8 @@ jobs:
     name: Audit suite (65 tests)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
       - name: Run audit suite
@@ -22,8 +22,8 @@ jobs:
     name: Zero production dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
       - name: Check
@@ -33,8 +33,8 @@ jobs:
     name: Next.js build smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/dev/scripts/check-zero-prod-deps.sh
+++ b/dev/scripts/check-zero-prod-deps.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Fail if package.json has any production dependencies.
+# GSP npm package must ship zero prod deps (installer uses Node builtins only).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+count=$(node -e "
+  const pkg = require('./package.json');
+  const deps = pkg.dependencies || {};
+  console.log(Object.keys(deps).length);
+")
+
+if [ "$count" -ne 0 ]; then
+  echo "✗ package.json has $count production dependency/dependencies. GSP must ship zero. Move to devDependencies." >&2
+  node -e "console.log(Object.keys(require('./package.json').dependencies || {}))" >&2
+  exit 1
+fi
+
+echo "✓ Zero production dependencies"


### PR DESCRIPTION
## Summary

Second wave of harness improvements from the 2026-06-05 audit. This PR addresses the **Sensors** dimension — promotes the existing local audit suite to a CI gate.

- `.github/workflows/audit.yml` runs on push to `main` and on every PR
- Three independent jobs:
  - **audit-tests** — `bash dev/scripts/audit-tests.sh` (65 tests, 8 suites)
  - **zero-prod-deps** — `bash dev/scripts/check-zero-prod-deps.sh` — guards GSP's zero-prod-deps invariant (the most damaging regression for our npm package, since a stray `dependencies` entry pulls deps into every `pnpm dlx get-shit-pretty` user)
  - **build-smoke** — `npm ci && npm run build`

## Independent of W1

This PR branches off `main`, not `harness/w1-contract` — the two waves are independent. Can merge in either order.

## Test plan

- [x] Local positive test: `bash dev/scripts/check-zero-prod-deps.sh` on current main → `✓ Zero production dependencies`
- [x] Local negative test: added a fake `dependencies` entry → script exits 1 with `✗ package.json has 1 production dependency` + lists the offender. Reverted.
- [x] Workflow YAML shape-checked (3 jobs, Node 24, no tabs)
- [x] Local audit suite green: `bash dev/scripts/audit-tests.sh` → 72 PASS / 2 pre-existing WARN / 0 FAIL
- [ ] CI runs green on this PR (will verify after open)

## Follow-up

- **W2b** — ESLint flat config for `src/` (independent, can interleave)
- **W3** — PreToolUse hooks; needs this PR green first per plan sequencing

🤖 Generated with [Claude Code](https://claude.com/claude-code)