### PR TITLE
harness(w3): PreToolUse guards for runtime dirs + zero prod deps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,18 @@ Key points:
 
 To reinstall after adding/removing files: `node bin/install.js --claude --local`
 
+## Claude Code settings
+
+`.claude/settings.json` is gitignored. The repo ships `claude-settings.template.json` with the project's hooks. To enable them locally:
+
+```bash
+cp claude-settings.template.json .claude/settings.json
+```
+
+Hooks shipped:
+- `scripts/check-runtime-edit.sh` — blocks `Edit`/`Write` on `.claude/`, `.opencode/`, `.gemini/`, `.agents/`, `.codex/` runtime dirs
+- `scripts/check-package-deps.sh` — blocks `package.json` edits that add a production dependency
+
 ## Editing rules
 
 - Agent source of truth: `gsp/agents/gsp-{name}.md`

--- a/claude-settings.template.json
+++ b/claude-settings.template.json
@@ -1,0 +1,23 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node .claude/hooks/statusline-dispatcher.js"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_ROOT}/scripts/check-runtime-edit.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_ROOT}/scripts/check-package-deps.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/check-package-deps.sh
+++ b/scripts/check-package-deps.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# PreToolUse blocker for Edit|Write on package.json.
+# Rejects edits whose new content introduces a non-empty top-level "dependencies" key.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+
+# Only check root package.json
+case "$FILE_PATH" in
+  *package.json) ;;
+  *) exit 0 ;;
+esac
+
+# Workspace package.json under node_modules — ignore
+case "$FILE_PATH" in
+  *node_modules*) exit 0 ;;
+esac
+
+# For Write: tool_input.content holds the full new file
+# For Edit: tool_input.new_string holds the replacement string
+NEW_CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // .tool_input.new_string // empty')
+
+if [ -z "$NEW_CONTENT" ]; then
+  exit 0
+fi
+
+# Look for a top-level "dependencies" key containing at least one quoted entry.
+# Pattern: "dependencies": { ... "<name>": ... }
+if echo "$NEW_CONTENT" | grep -qE '"dependencies"\s*:\s*\{[^}]*"[^"]+"\s*:'; then
+  echo "✗ BLOCKED: package.json edit would add a production dependency." >&2
+  echo "  GSP npm package must ship zero prod deps. Use devDependencies instead." >&2
+  echo "  CI (Harness Audit / zero-prod-deps) enforces this on every PR." >&2
+  exit 2
+fi
+
+exit 0

--- a/scripts/check-runtime-edit.sh
+++ b/scripts/check-runtime-edit.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# PreToolUse blocker for Edit|Write tools.
+# Rejects edits to symlinked runtime dirs — source of truth is gsp/.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Match runtime dirs anywhere in the path. Source under gsp/ is allowed.
+case "$FILE_PATH" in
+  *.claude/skills/*|*.claude/agents/*|*.claude/prompts/*|*.claude/templates/*|\
+  *.opencode/skills/*|*.opencode/agents/*|*.opencode/prompts/*|*.opencode/templates/*|\
+  *.gemini/skills/*|*.gemini/agents/*|*.gemini/prompts/*|*.gemini/templates/*|\
+  *.agents/skills/*|*.codex/prompts/*|*.codex/templates/*)
+    echo "✗ BLOCKED: runtime dirs (.claude/, .opencode/, .gemini/, .agents/, .codex/) are symlinks/installer-managed." >&2
+    echo "  Edit the source under gsp/ instead. Path was: $FILE_PATH" >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/scripts/lint-check.sh
+++ b/scripts/lint-check.sh
@@ -19,11 +19,14 @@ case "$FILE_PATH" in
     ;;
 esac
 
-# Try project-local linter, fall back gracefully
+# Try project-local linter, fall back gracefully.
+# Surface eslint diagnostics on stderr — non-blocking is fine, silent is not.
 if [ -f "node_modules/.bin/eslint" ]; then
-  node_modules/.bin/eslint --fix --quiet "$FILE_PATH" 2>/dev/null
+  node_modules/.bin/eslint --fix --quiet "$FILE_PATH" \
+    || echo "lint-check: eslint reported issues on $FILE_PATH (non-blocking)" >&2
 elif command -v npx &>/dev/null && [ -f "package.json" ] && grep -q "eslint" package.json 2>/dev/null; then
-  npx --no-install eslint --fix --quiet "$FILE_PATH" 2>/dev/null
+  npx --no-install eslint --fix --quiet "$FILE_PATH" \
+    || echo "lint-check: eslint reported issues on $FILE_PATH (non-blocking)" >&2
 fi
 
 # Never block the agent


### PR DESCRIPTION
## Summary

Final wave of harness improvements from the 2026-06-05 audit. Addresses the **Enforcement** dimension — converts two prose rules into hard `PreToolUse` blockers.

- `scripts/check-runtime-edit.sh` — blocks `Edit`/`Write` on `.claude/`, `.opencode/`, `.gemini/`, `.agents/`, `.codex/` runtime dirs (which are symlinks/installer-managed; source lives in `gsp/`)
- `scripts/check-package-deps.sh` — blocks `package.json` edits that introduce a non-empty top-level `dependencies` key (preserves the zero-prod-deps invariant CI also enforces)
- `claude-settings.template.json` — tracked template; contributors copy to `.claude/settings.json` since `.claude/` is gitignored. CLAUDE.md documents the copy step.
- `scripts/lint-check.sh` — stops swallowing eslint stderr (diagnostics now surface as non-blocking messages; exit 0 preserved)

## Test plan

Unit tests on the block scripts:

**check-runtime-edit.sh** — 5 cases, all correct:
- `.claude/skills/gsp-color/SKILL.md` → ✗ BLOCKED (exit 2)
- `gsp/skills/gsp-color/SKILL.md` → allowed (exit 0)
- `src/components/foo.tsx` → allowed (exit 0)
- `.opencode/agents/gsp-x.md` → ✗ BLOCKED (exit 2)
- Absolute path with `.claude/` → ✗ BLOCKED (exit 2)

**check-package-deps.sh** — 6 cases, all correct:
- Write `package.json` adding `"dependencies": { "react": ... }` → ✗ BLOCKED
- Empty `"dependencies": {}` → allowed
- Non-package.json file → allowed
- Edit with `new_string` adding dep → ✗ BLOCKED
- `node_modules/foo/package.json` → allowed
- `devDependencies` only → allowed

- [x] `bash dev/scripts/audit-tests.sh` → 72 PASS / 2 pre-existing WARN / 0 FAIL
- [ ] CI green on this PR
- [ ] **Manual integration test** (requires fresh Claude Code session — see below)

## Manual integration test (required before merging)

After merging, copy `claude-settings.template.json` to `.claude/settings.json` and start a fresh Claude Code session. Then:

1. Ask Claude to edit `.claude/skills/gsp-color/SKILL.md`. Expected: tool call blocked with `BLOCKED: runtime dirs ... Edit the source under gsp/ instead.`
2. Ask Claude to add `"dependencies": { "react": "^19" }` to `package.json`. Expected: tool call blocked with `BLOCKED: package.json edit would add a production dependency.`

If either fails to block, the hook isn't wired correctly — check `claude-settings.template.json` vs `.claude/settings.json` and restart the session.

## Follow-up

Filed as future issue: have `bin/install.js` write `.claude/settings.json` from a source file (e.g. `gsp/hooks/claude-settings.json`), removing the manual `cp` step for contributors.

After this PR merges, re-run `/harness-doctor` to confirm the final scorecard:
- Contract ✓, Skills ✓✓, Guides ✓✓, Sensors ✓, **Enforcement ✓** (was ⚠), Memory ✓, Improvement loop ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)