### PR TITLE
harness(x): cross-reference resolution sensor + fix builder theming path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ bash dev/scripts/audit-tests.sh installer    # installer correctness
 bash dev/scripts/audit-tests.sh runtime      # runtime compatibility
 bash dev/scripts/audit-tests.sh templates    # template coherence
 bash dev/scripts/audit-tests.sh tokenbudget  # token budget analysis
+bash dev/scripts/audit-tests.sh references   # cross-skill / template / hook ref resolution
 ```
 
 ### Using dev skills

--- a/dev/scripts/audit-tests.sh
+++ b/dev/scripts/audit-tests.sh
@@ -996,6 +996,97 @@ if should_run templates; then
   fi
 fi
 
+# ── X: Cross-Reference Resolution ─────────────────────
+
+if should_run references; then
+  header "Cross-Reference Resolution"
+  X_BROKEN=0
+  X_CHECKED=0
+  X_FILES=0
+  # Skip refs containing template placeholders like {name}, {preset}, {path}
+  is_placeholder() { [[ "$1" == *"/{"*"}"* ]]; }
+
+  X_SOURCES=$(find gsp/skills gsp/agents -name "*.md" 2>/dev/null; echo gsp/hooks/hooks.json)
+
+  for src in $X_SOURCES; do
+    [[ -f "$src" ]] || continue
+    X_FILES=$((X_FILES + 1))
+    skill_dir=$(dirname "$src")
+
+    # X1: ${CLAUDE_SKILL_DIR}/../<rel> → gsp/skills/<rel>
+    while IFS= read -r ref; do
+      [[ -z "$ref" ]] && continue
+      is_placeholder "$ref" && continue
+      rel="${ref#\${CLAUDE_SKILL_DIR\}/../}"
+      target="gsp/skills/$rel"
+      X_CHECKED=$((X_CHECKED + 1))
+      if [[ ! -e "$target" ]]; then
+        fail "X1 broken cross-skill ref" "$src → $ref (expected $target)"
+        X_BROKEN=$((X_BROKEN + 1))
+      fi
+    done < <(grep -ohE '\$\{CLAUDE_SKILL_DIR\}/\.\./[^./"`\$\) ][^"`\$\) ]*' "$src" 2>/dev/null | sort -u)
+
+    # X2: ${CLAUDE_SKILL_DIR}/../../<rel> → gsp/<rel> OR repo root <rel>
+    while IFS= read -r ref; do
+      [[ -z "$ref" ]] && continue
+      is_placeholder "$ref" && continue
+      rel="${ref#\${CLAUDE_SKILL_DIR\}/../../}"
+      X_CHECKED=$((X_CHECKED + 1))
+      if [[ ! -e "gsp/$rel" && ! -e "$rel" ]]; then
+        fail "X2 broken root-level ref" "$src → $ref (expected gsp/$rel or $rel)"
+        X_BROKEN=$((X_BROKEN + 1))
+      fi
+    done < <(grep -ohE '\$\{CLAUDE_SKILL_DIR\}/\.\./\.\./[^"`\$\) ]+' "$src" 2>/dev/null | sort -u)
+
+    # X3: methodology/gsp-<name>.md → relative to skill_dir
+    # Exclude lines containing ${CLAUDE_SKILL_DIR} — those are Pattern 1 refs that
+    # happen to contain "methodology/" as a sub-path.
+    while IFS= read -r ref; do
+      [[ -z "$ref" ]] && continue
+      is_placeholder "$ref" && continue
+      target="$skill_dir/$ref"
+      X_CHECKED=$((X_CHECKED + 1))
+      if [[ ! -e "$target" ]]; then
+        fail "X3 broken methodology ref" "$src → $ref (expected $target)"
+        X_BROKEN=$((X_BROKEN + 1))
+      fi
+    done < <(grep -v '\$\{CLAUDE_SKILL_DIR\}' "$src" 2>/dev/null | grep -ohE 'methodology/gsp-[a-z-]+\.md' | sort -u)
+
+    # X4: SubagentStop matchers (hooks.json only) → gsp/agents/<matcher>.md
+    if [[ "$src" == "gsp/hooks/hooks.json" ]]; then
+      while IFS= read -r matcher; do
+        [[ -z "$matcher" ]] && continue
+        target="gsp/agents/$matcher.md"
+        X_CHECKED=$((X_CHECKED + 1))
+        if [[ ! -e "$target" ]]; then
+          fail "X4 broken hook matcher" "$src → $matcher (expected $target)"
+          X_BROKEN=$((X_BROKEN + 1))
+        fi
+      done < <(jq -r '.. | objects | select(.matcher) | .matcher' "$src" 2>/dev/null | grep -E '^gsp-' | sort -u)
+    fi
+
+    # X5: @<path> inside <execution_context> blocks (markdown only) → relative to skill_dir
+    if [[ "$src" == *.md ]]; then
+      while IFS= read -r ref; do
+        [[ -z "$ref" ]] && continue
+        is_placeholder "$ref" && continue
+        target="$skill_dir/$ref"
+        X_CHECKED=$((X_CHECKED + 1))
+        if [[ ! -e "$target" ]]; then
+          fail "X5 broken @-import" "$src → @$ref (expected $target)"
+          X_BROKEN=$((X_BROKEN + 1))
+        fi
+      done < <(awk '/<execution_context>/,/<\/execution_context>/' "$src" 2>/dev/null \
+        | grep -oE '@[^[:space:]\)\}]+\.(md|yml|json)' \
+        | sed 's/^@//' | sort -u)
+    fi
+  done
+
+  if [[ $X_BROKEN -eq 0 ]]; then
+    pass "X cross-reference resolution ($X_CHECKED refs checked across $X_FILES source files)"
+  fi
+fi
+
 # ── P: Prompt Quality ─────────────────────────────────
 
 if should_run prompts; then

--- a/gsp/skills/gsp-project-build/methodology/gsp-project-builder.md
+++ b/gsp/skills/gsp-project-build/methodology/gsp-project-builder.md
@@ -196,7 +196,7 @@ These rules are always enforced for shadcn targets. They reflect the official sh
 
 Full reference: `${CLAUDE_SKILL_DIR}/../gsp-project-critique/anti-patterns.md` (available via Read for the complete list with fixes).
 
-**Theming reference:** when building or fixing themes, read `${CLAUDE_SKILL_DIR}/../../gsp-scaffold/shadcn-theming.md` — full token table, dark mode setup, common theming bugs and fixes.
+**Theming reference:** when building or fixing themes, read `${CLAUDE_SKILL_DIR}/../gsp-scaffold/shadcn-theming.md` — full token table, dark mode setup, common theming bugs and fixes.
 
 ## Visual Quality Checklist
 


### PR DESCRIPTION
## Summary

Final sensor from the harness audit — the behavioral-but-deterministic gate identified as gap #4 in the post-W3 re-audit. Catches the **broken cross-reference** class: rename a file, every existing audit test still passes, but the runtime Read fails.

- New `X` suite in `dev/scripts/audit-tests.sh` (~90 lines, suite name `references`)
- Covers 5 reference patterns; placeholder paths (`{name}`, `{preset}`) skipped; `${VAR}` not mistaken for them
- Invocable: `bash dev/scripts/audit-tests.sh references`
- Runs in <5s on this codebase, $0 LLM cost
- No CI workflow change — picks up via existing `Harness Audit` from W2a

## Patterns

| | Pattern | Resolves to |
|---|---|---|
| X1 | `${CLAUDE_SKILL_DIR}/../<rel>` | `gsp/skills/<rel>` |
| X2 | `${CLAUDE_SKILL_DIR}/../../<rel>` | `gsp/<rel>` or repo root `<rel>` |
| X3 | `methodology/gsp-<name>.md` | relative to skill dir |
| X4 | SubagentStop `"matcher": "gsp-<name>"` | `gsp/agents/<m>.md` |
| X5 | `@<path>.{md,yml,json}` in `<execution_context>` | relative to skill dir |

## Real bug found + fixed

R8 surfaced one production bug on first deployment:

`gsp/skills/gsp-project-build/methodology/gsp-project-builder.md` line 199 cited `${CLAUDE_SKILL_DIR}/../../gsp-scaffold/shadcn-theming.md` — one `../` too many; the correct path is `${CLAUDE_SKILL_DIR}/../gsp-scaffold/shadcn-theming.md` (file lives at `gsp/skills/gsp-scaffold/shadcn-theming.md`). Fixed in this commit. Builder agents would have failed to read the theming reference at runtime.

This is exactly the silent-failure class the sensor exists to catch — landing it together with the find is the right shape.

## Test plan

- [x] Baseline: full suite 72 PASS → 73 PASS after X
- [x] Standalone: `bash dev/scripts/audit-tests.sh references` → `✓ X cross-reference resolution (74 refs checked across 148 source files)`
- [x] **Negative test:** temporarily renamed `gsp/skills/gsp-art/terminal-art.md`; X1 flagged the broken ref from `gsp-pretty/SKILL.md` with source/target; reverted; X passed (74 refs across 148 files)
- [ ] CI green on this PR

## Closes the harness audit

After this lands, all 5 audit gaps (Contract, Sensors, Enforcement, Memory, and the behavioral sensor gap) are addressed. Expected post-merge scorecard: Contract ✓, Skills ✓✓, Guides ✓✓, **Sensors ✓✓** (deterministic behavioral now covered), Enforcement ✓, Memory ✓, Improvement loop ✓.

## Out of scope (per spec)

- Live LLM CI smoke
- Snapshot/eval testing
- Installer round-trip
- `scan.sh` symlink bug (upstream)

Spec: `docs/superpowers/specs/2026-06-05-r8-reference-resolution-sensor-design.md` (local-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)