### PR TITLE
feat(#211): user-declared output modes for project pipeline

### DIFF
--- a/gsp/hooks/hooks.json
+++ b/gsp/hooks/hooks.json
@@ -18,6 +18,19 @@
           {
             "type": "prompt",
             "prompt": "The gsp-project-designer agent just finished. Verify: (1) at least one design/screen-*.md chunk was written, (2) design/INDEX.md was written. Report any missing deliverables to the user."
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_ROOT}/scripts/check-artifact-size.sh gsp-project-designer"
+          }
+        ]
+      },
+      {
+        "matcher": "gsp-project-researcher",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_ROOT}/scripts/check-artifact-size.sh gsp-project-researcher"
           }
         ]
       },
@@ -27,6 +40,10 @@
           {
             "type": "prompt",
             "prompt": "The gsp-project-critic agent just finished. Verify: (1) critique/critique.md was written with a heuristics score, (2) critique/prioritized-fixes.md was written, (3) critique/strengths.md was written. Report any missing deliverables to the user."
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_ROOT}/scripts/check-artifact-size.sh gsp-project-critic"
           }
         ]
       },
@@ -54,6 +71,10 @@
           {
             "type": "prompt",
             "prompt": "The gsp-project-builder agent just finished. Verify: (1) a log file was written under build/logs/ (foundations.md, component-*.md, or screen-*.md depending on execution mode), (2) no files were left with TODO/FIXME placeholder code. Note: build/INDEX.md is written at finalize, not by individual agents — do not flag its absence. Report any missing deliverables to the user."
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_ROOT}/scripts/check-artifact-size.sh gsp-project-builder"
           }
         ]
       },
@@ -63,6 +84,10 @@
           {
             "type": "prompt",
             "prompt": "The gsp-project-reviewer agent just finished. Verify: (1) acceptance-report.md was written, (2) issues.md was written, (3) review/INDEX.md was written, (4) verdict is clearly stated as Pass, Conditional Pass, or Fail. Report any issues to the user."
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_ROOT}/scripts/check-artifact-size.sh gsp-project-reviewer"
           }
         ]
       },
@@ -72,6 +97,10 @@
           {
             "type": "prompt",
             "prompt": "The gsp-accessibility-auditor agent just finished. Verify: (1) accessibility-audit.md was written, (2) accessibility-fixes.md was written. Report any missing deliverables to the user."
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_ROOT}/scripts/check-artifact-size.sh gsp-accessibility-auditor"
           }
         ]
       },

--- a/gsp/policies/output-modes.md
+++ b/gsp/policies/output-modes.md
@@ -1,0 +1,161 @@
+# Output modes policy
+
+Single source of truth for **project-pipeline** output adaptation. Pipeline skills and agent methodologies cite this file instead of duplicating rules.
+
+**Scope:** This policy applies to the **project pipeline only** — `gsp-project-brief`, `gsp-project-research`, `gsp-project-design`, `gsp-project-critique`, `gsp-project-build`, `gsp-project-review`. The **brand pipeline always runs at full fidelity** (brand outputs are reused across many projects; the brand is the foundation, not the variable).
+
+**Read by:** project-pipeline skills, project-pipeline agent methodologies, `scripts/check-artifact-size.sh` (SubagentStop hook).
+
+---
+
+## Three modes
+
+| Mode | Persistence | When to use |
+|---|---|---|
+| `chat` | Phase brief returned in conversation. Only `STATE.md` updated. No phase chunks land on disk. | One-off questions, exploration, brainstorming a feature shape. User has not committed to building. |
+| `compact` *(default)* | One file per phase (`{phase}/PHASE.md`) with H2 sections matching the chunk vocabulary. | Focused refactors, single-component features, small new screens. The 80% case. |
+| `full` | Today's chunk-per-axis structure (5–13 files per phase). | New multi-screen app, brand-defining work, large pivots, anything where pivot-resilience matters. |
+
+**Default for new projects:** `compact`. Declared at `/gsp-start` and stored in `config.json` `preferences.project_size`.
+
+---
+
+## Per-phase output by mode
+
+The chunk *vocabulary* is preserved across all modes — only the **file partitioning** changes. A designer reading any mode sees the same H2 headers (Personas, IA, Component Spec, Microcopy, Accessibility, Visual Design, UX Flows, Responsive, Micro-interactions).
+
+### Brief
+
+| Mode | Files | Sections |
+|---|---|---|
+| `chat` | none (brief lives in conversation) | scope, target adaptations, install manifest, gap analysis, file references |
+| `compact` | `brief/PHASE.md` (≤300 lines) | same H2 sections |
+| `full` | 5 files: `scope.md`, `target-adaptations.md`, `install-manifest.md`, `gap-analysis.md`, `file-references.md` + `INDEX.md` | one file per concern |
+
+### Research
+
+| Mode | Files | Sections |
+|---|---|---|
+| `chat` | none | recommendations only, returned to chat |
+| `compact` | `research/PHASE.md` (≤400 lines) | UX patterns, competitor UX, technical research, accessibility patterns, content strategy, reference specs, recommendations |
+| `full` | 7 files + INDEX | one per concern |
+
+### Design
+
+| Mode | Files | Sections |
+|---|---|---|
+| `chat` | none | high-level shape returned to chat |
+| `compact` | `design/PHASE.md` per screen + `design/SHARED.md` | per-screen H2s for component-spec, visual-design, ux-flows, microcopy, accessibility; shared = personas, IA, nav, micro-interactions, responsive, component-plan |
+| `full` | `screen-NN-name.md` × N + `shared/` folder (6 files) + INDEX | today's structure |
+
+### Critique
+
+| Mode | Files | Sections |
+|---|---|---|
+| `chat` | none | top-3 blockers + verdict to chat |
+| `compact` | `critique/PHASE.md` (≤300 lines) | critique + heuristics score, prioritized fixes, strengths, alternative directions, accessibility audit, accessibility fixes |
+| `full` | 6 files + INDEX | today's structure |
+
+### Build
+
+Build phase persists code, not planning. Mode affects only the **build log** verbosity:
+
+| Mode | Build logs |
+|---|---|
+| `chat` | summary log only |
+| `compact` | one `build/BUILD-LOG.md` consolidated across foundations/components/screens |
+| `full` | per-execution log (today: foundations.md, component-*.md, screen-*.md) |
+
+### Review
+
+| Mode | Files | Sections |
+|---|---|---|
+| `chat` | verdict + top issues to chat | n/a |
+| `compact` | `review/PHASE.md` | acceptance report + issues |
+| `full` | acceptance-report.md, issues.md, INDEX | today |
+
+---
+
+## Skip-if-not-present doctrine
+
+**Applies in all modes.** Empty sections pollute the artifact. If a section has no real content for this project, omit it — do not pad to look thorough.
+
+Examples of legitimate skips:
+
+| Section | Skip when |
+|---|---|
+| `competitor-ux` | scope is a refactor of existing code — no competitors to study |
+| `personas` | scope is a developer-tool feature where personas are flat ("the developer using this") |
+| `responsive` | feature is desktop-only or platform-fixed |
+| `microcopy` | feature has no user-facing strings |
+| `accessibility-audit` | scope is non-UI (e.g., build configuration, infra) |
+| `alternative-directions` | scope is constrained by an external decision the user already locked |
+| `reference-specs` | scope is internal — no external references add signal |
+
+**Hard rule:** if a chunk would have fewer than ~20 lines of unique, project-specific content, omit it entirely. Do not write `_Nothing meaningful for this project._` — just leave it out and let `INDEX.md` (full mode) or section absence (compact mode) tell the reader.
+
+Cite this rule by name: **"skip-if-not-present per policies/output-modes.md."**
+
+---
+
+## Mode is the user's choice, declared once
+
+- **Declared at:** `/gsp-start` (or directly editable in `config.json`)
+- **Field:** `preferences.project_size` ∈ `"chat" | "compact" | "full"`
+- **Default:** `compact`
+- **No auto-detection.** Briefs precede screen enumeration; heuristic detection at brief-time is structurally unreliable (per #211 verification). User-declared is the only honest answer.
+
+### Upgrading mid-pipeline
+
+If the user pivots from a focused refactor into a larger scope mid-pipeline, they can:
+
+1. Edit `config.json` to upgrade `project_size`
+2. Re-run the phase that needs expansion — the agent will re-emit at the new mode
+3. Existing compact-mode `PHASE.md` files are preserved as the synthesis input
+
+A future `/gsp-resize` skill may automate step 2; not required for v1.
+
+---
+
+## Interaction with existing scope axes
+
+The project config carries several orthogonal scope axes already. `project_size` is a fourth, and its interaction is defined here:
+
+| Axis | Values | Interaction with `project_size` |
+|---|---|---|
+| `design_scope` | `tokens`, `partial`, `full` | Orthogonal. `tokens` skips brief/research/design regardless of size. `partial` and `full` honor size mode. |
+| `implementation_target` | `code`, `figma` | Orthogonal. Figma builds inherit the mode for the design phase output. |
+| `codebase_type` | `greenfield`, `existing` | Soft signal only. A greenfield project at `compact` mode still gets the compact structure — but the user should consider `full` for greenfield since pivot-resilience matters more there. |
+| `repo_type` | `single`, `monorepo` | Orthogonal. |
+
+**Conflict resolution:** if a higher-level gate (e.g., `design_scope: tokens`) bypasses a phase, `project_size` has no effect on that phase. Explicit gates always win.
+
+---
+
+## Enforcement
+
+Prompt-level guidance alone is unreliable — agents have historically padded chunks despite "skip if irrelevant" guidance (per #211 issue body).
+
+Therefore: a **`SubagentStop` hook** (`scripts/check-artifact-size.sh`) runs after each project-pipeline agent completes. The hook:
+
+1. Reads `project_size` from `.design/projects/{slug}/config.json` (or fallback to `preferences.project_size` in the parent config)
+2. Counts files emitted in the relevant phase directory
+3. Compares against the mode's budget (see per-phase table above)
+4. If over budget: blocks completion, requires the agent to consolidate
+
+The hook is the only reliable enforcement layer. Skill body + agent methodology + this policy provide the contract; the hook enforces it.
+
+---
+
+## What this policy does **not** cover
+
+- **Brand pipeline** — always full fidelity. See `gsp/skills/gsp-brand-guidelines/` for the brand artifact contract.
+- **Expertise skill outputs** (`gsp-style`, `gsp-color`, `gsp-typography`, etc.) — these are knowledge-owner skills, not pipeline phases. Their outputs are not mode-adaptive.
+- **The `.design/CLAUDE.md` registry** — unchanged.
+- **Token volume of agent **inputs**** — this policy targets durable artifacts on disk, not agent prompt size. See `dev/scripts/token-budget.sh` for input-side budgeting.
+
+---
+
+## Issue link
+
+This policy was authored for issue [#211](https://github.com/jubscodes/get-shit-pretty/issues/211) — *"perf: planning theater — chunk-per-axis design produces 7-8× planning-to-code ratio on focused projects."*

--- a/gsp/skills/gsp-accessibility-audit/methodology/gsp-accessibility-auditor.md
+++ b/gsp/skills/gsp-accessibility-audit/methodology/gsp-accessibility-auditor.md
@@ -6,6 +6,10 @@ Act as Apple Accessibility Specialist. Your job is to audit designs or code agai
 Accessibility is a core quality requirement.
 </role>
 
+<persistence>
+When spawned by `/gsp-project-critique`, honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` — read `preferences.project_size` from the project config (default `compact`). Emit the per-mode artifact count specified there; do NOT pad. **Skip-if-not-present:** omit `accessibility-audit` when scope is non-UI. The `SubagentStop` hook (`scripts/check-artifact-size.sh`) will reject output that exceeds the mode's budget.
+</persistence>
+
 <methodology>
 ## Audit Process
 

--- a/gsp/skills/gsp-project-brief/SKILL.md
+++ b/gsp/skills/gsp-project-brief/SKILL.md
@@ -22,6 +22,7 @@ Scope the project and plan adaptations from the brand system.
 
 **Input:** Brand system (via brand.ref) + project BRIEF.md + config.json
 **Output:** `{project}/brief/` (scope.md, target-adaptations.md, conditionals, INDEX.md)
+**Output mode:** Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` per `preferences.project_size` (default `compact`). Chunk file counts and consolidation rules live in the policy.
 </objective>
 
 <execution_context>

--- a/gsp/skills/gsp-project-build/SKILL.md
+++ b/gsp/skills/gsp-project-build/SKILL.md
@@ -56,6 +56,7 @@ Implement designs as production-ready code in the codebase via phased pipeline w
 **Input:** Design chunks + research chunks + brief chunks + brand system chunks
 **Output:** Code in the codebase + `{project}/build/BUILD-LOG.md` + `{project}/build/SCAFFOLD-LOG.md`
 **Agent:** `gsp-project-builder` (spawned per phase with execution mode)
+**Output mode:** Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` per `preferences.project_size` (default `compact`). Build-log verbosity adapts; code output is unaffected.
 </objective>
 
 <execution_context>

--- a/gsp/skills/gsp-project-build/methodology/gsp-project-builder.md
+++ b/gsp/skills/gsp-project-build/methodology/gsp-project-builder.md
@@ -11,6 +11,10 @@ You adapt your approach based on the `implementation_target`:
 - **`code`** — Derive component structure from design or plan, implement in codebase
 - **`skip` (no plan)** — Build directly from design chunks + brand system, derive component architecture yourself
 
+## Output mode
+
+Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` — read `preferences.project_size` from the project config (default `compact`). Build-log verbosity adapts: `chat` mode emits a summary only; `compact` consolidates logs into a single `build/BUILD-LOG.md`; `full` emits per-execution logs (today's behavior). **Code output is unaffected** — the policy never trims code. The `SubagentStop` hook will reject log output that exceeds the mode's budget.
+
 ## Execution modes
 
 You are spawned with an `execution_mode` parameter. Follow the mode strictly:

--- a/gsp/skills/gsp-project-critique/SKILL.md
+++ b/gsp/skills/gsp-project-critique/SKILL.md
@@ -21,6 +21,7 @@ Critique design quality and audit accessibility compliance.
 **Input:** All prior project chunks + brand identity
 **Output:** `{project}/critique/` (critique + accessibility chunks + INDEX.md) + exports/INDEX.md update
 **Agents:** `gsp-project-critic` + `gsp-accessibility-auditor`
+**Output mode:** Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` per `preferences.project_size` (default `compact`). Chunk file counts and consolidation rules live in the policy.
 </objective>
 
 <process>

--- a/gsp/skills/gsp-project-critique/methodology/gsp-project-critic.md
+++ b/gsp/skills/gsp-project-critique/methodology/gsp-project-critic.md
@@ -2,6 +2,10 @@
 You are a GSP design critic spawned by `/gsp-project-critique`. Act as an Apple Design Director. Move from "why" (strategy) → "what" (brand, usability, accessibility) → "how" (content, implementation, taste) → "what next" (synthesis). Every criticism includes a concrete fix. Tone: senior designer who makes you better, not the one who tears you down.
 </role>
 
+<persistence>
+Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` — read `preferences.project_size` from the project config (default `compact`). Emit the per-mode artifact count specified there; do NOT pad chunks to look thorough. **Skip-if-not-present:** omit sections with no real content (e.g., `alternative-directions` when scope is constrained). The `SubagentStop` hook (`scripts/check-artifact-size.sh`) will reject output that exceeds the mode's budget.
+</persistence>
+
 <methodology>
 ## Critique Process
 

--- a/gsp/skills/gsp-project-design/SKILL.md
+++ b/gsp/skills/gsp-project-design/SKILL.md
@@ -23,6 +23,7 @@ Design core UI/UX screens and interaction flows.
 **Input:** Research + brief + brand system + project BRIEF.md
 **Output:** `{project}/design/` (screen chunks + shared/ + INDEX.md) + exports/INDEX.md update
 **Agent:** `gsp-project-designer`
+**Output mode:** Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` per `preferences.project_size` (default `compact`). Chunk file counts and consolidation rules live in the policy.
 </objective>
 
 <execution_context>

--- a/gsp/skills/gsp-project-design/methodology/gsp-project-designer.md
+++ b/gsp/skills/gsp-project-design/methodology/gsp-project-designer.md
@@ -10,6 +10,10 @@ When an **Existing Components** inventory is provided (for `shadcn`, `rn-reusabl
 **Custom references:** When files from `{PROJECT_PATH}/references/` are provided (screenshots, wireframes, brand guidelines, competitor examples), incorporate them into your design decisions. Reference them explicitly in screen chunks where they influenced the design.
 </role>
 
+<persistence>
+Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` — read `preferences.project_size` from the project config (default `compact`). Emit the per-mode artifact count specified there; do NOT pad chunks to look thorough. **Skip-if-not-present:** omit sections with no real content for this project. The `SubagentStop` hook (`scripts/check-artifact-size.sh`) will reject output that exceeds the mode's budget.
+</persistence>
+
 <methodology>
 ## Design Process
 

--- a/gsp/skills/gsp-project-research/SKILL.md
+++ b/gsp/skills/gsp-project-research/SKILL.md
@@ -26,6 +26,7 @@ Deep research into UX patterns, competitor experiences, and technical approaches
 **Input:** Brief scope + brand system + project BRIEF.md
 **Output:** `{project}/research/` (6 research chunks + INDEX.md)
 **Agent:** `gsp-project-researcher`
+**Output mode:** Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` per `preferences.project_size` (default `compact`). Chunk file counts and consolidation rules live in the policy.
 </objective>
 
 <execution_context>

--- a/gsp/skills/gsp-project-research/methodology/gsp-project-researcher.md
+++ b/gsp/skills/gsp-project-research/methodology/gsp-project-researcher.md
@@ -8,6 +8,10 @@ You research UX patterns for the product type, analyze how competitors solve sim
 This is NOT brand-level discovery (that happens in `/gsp-brand-discover`). You build on brand discovery by going deep into project-specific concerns. If the brand discovery already covered competitor analysis at a brand level, you focus on competitor *UX* at a product level.
 </role>
 
+<persistence>
+Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` — read `preferences.project_size` from the project config (default `compact`). Emit the per-mode artifact count specified there; do NOT pad chunks to look thorough. **Skip-if-not-present:** omit sections with no real content (e.g., `competitor-ux` when the scope is a refactor of existing code; `reference-specs` when scope is internal). The `SubagentStop` hook (`scripts/check-artifact-size.sh`) will reject output that exceeds the mode's budget.
+</persistence>
+
 <methodology>
 ## Research Process
 

--- a/gsp/skills/gsp-project-review/SKILL.md
+++ b/gsp/skills/gsp-project-review/SKILL.md
@@ -23,6 +23,7 @@ QA validate the codebase implementation against design intent.
 **Input:** BUILD-LOG.md + actual codebase files + `git diff` + design chunks + brand system
 **Output:** `{project}/review/` (acceptance-report.md + issues.md + INDEX.md) + exports/INDEX.md update
 **Agent:** `gsp-project-reviewer`
+**Output mode:** Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` per `preferences.project_size` (default `compact`). Chunk file counts and consolidation rules live in the policy.
 </objective>
 
 <execution_context>

--- a/gsp/skills/gsp-project-review/methodology/gsp-project-reviewer.md
+++ b/gsp/skills/gsp-project-review/methodology/gsp-project-reviewer.md
@@ -6,6 +6,10 @@ Act as a Senior QA Design Engineer. Your job is to validate that the actual code
 You are the final quality gate. You review real code, not specs.
 </role>
 
+<persistence>
+Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` — read `preferences.project_size` from the project config (default `compact`). Emit the per-mode artifact count specified there; do NOT pad. The `SubagentStop` hook (`scripts/check-artifact-size.sh`) will reject output that exceeds the mode's budget.
+</persistence>
+
 <methodology>
 ## QA Process
 

--- a/gsp/skills/gsp-start/SKILL.md
+++ b/gsp/skills/gsp-start/SKILL.md
@@ -121,6 +121,19 @@ Show compact brand (single-line if complete) + full project pipeline flow. Then 
 
 Weave codebase signals into the greeting naturally when found.
 
+## Step 2.5: Output mode (project flows only)
+
+If the user is starting a **project pipeline** flow (Design project, Both, Quick project, or Continue project), ask one targeted question before routing:
+
+Use `AskUserQuestion`:
+- **Compact** *(recommended)* — "One file per phase, designer-readable. Good for focused refactors and single-feature work. The 80% case."
+- **Full** — "Chunk-per-axis (5-13 files per phase). Use for new multi-screen apps or large pivots where pivot-resilience matters."
+- **Chat** — "Plan in conversation only. Nothing persists to disk. Use for one-off exploration."
+
+Persist the answer to the project's `config.json` `preferences.project_size` when the project is created (default = `compact`). The brand pipeline ignores this field — brand always runs at full fidelity. See `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md`.
+
+**Skip this step for brand-only flows** (New brand, Evolve existing brand) — brand pipeline is mode-independent.
+
 ## Step 3: Route
 
 From the greeting exchange, route to the right skill:

--- a/gsp/templates/projects/config.json
+++ b/gsp/templates/projects/config.json
@@ -12,6 +12,7 @@
     "implementation_target": "code",
     "codebase_type": "greenfield",
     "design_scope": "full",
+    "project_size": "compact",
     "style_preset": "",
     "repo_type": "single",
     "app_path": "",

--- a/scripts/check-artifact-size.sh
+++ b/scripts/check-artifact-size.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SubagentStop hook — verify a project-pipeline agent's output respects the project's
+# declared output mode (chat | compact | full). See gsp/policies/output-modes.md.
+#
+# Usage: check-artifact-size.sh <agent-name>
+# Exit 0 if within budget (or skip cases); exit 1 with stdout message if over budget.
+
+set -euo pipefail
+
+AGENT="${1:-}"
+if [ -z "$AGENT" ]; then exit 0; fi
+
+# Locate the active project (first one under .design/projects/ with a STATE.md).
+PROJECT_PATH=""
+if [ -d ".design/projects" ]; then
+  for dir in .design/projects/*/; do
+    if [ -f "${dir}STATE.md" ]; then
+      PROJECT_PATH="$dir"
+      break
+    fi
+  done
+fi
+if [ -z "$PROJECT_PATH" ]; then exit 0; fi
+
+CONFIG="${PROJECT_PATH}config.json"
+if [ ! -f "$CONFIG" ]; then exit 0; fi
+
+# Extract project_size. Cheap grep/sed — avoids a jq dependency since the npm package
+# ships zero prod deps.
+MODE=$(grep -o '"project_size"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG" \
+  | sed 's/.*"\([^"]*\)"$/\1/' | head -n 1)
+if [ -z "$MODE" ]; then MODE="compact"; fi
+
+# Agent → phase directory mapping.
+case "$AGENT" in
+  gsp-project-researcher)        PHASE_DIR="research" ;;
+  gsp-project-designer)          PHASE_DIR="design" ;;
+  gsp-project-critic)            PHASE_DIR="critique" ;;
+  gsp-accessibility-auditor)     PHASE_DIR="critique" ;;
+  gsp-project-builder)           PHASE_DIR="build" ;;
+  gsp-project-reviewer)          PHASE_DIR="review" ;;
+  *) exit 0 ;;
+esac
+
+PHASE_PATH="${PROJECT_PATH}${PHASE_DIR}"
+if [ ! -d "$PHASE_PATH" ]; then exit 0; fi
+
+# Per-mode budget. See gsp/policies/output-modes.md for the canonical table.
+case "$MODE" in
+  chat)
+    MAX_FILES=1
+    MAX_LINES=50
+    ;;
+  compact)
+    MAX_FILES=3
+    MAX_LINES=500
+    ;;
+  full)
+    # Generous ceiling for full mode — only catches pathological output.
+    MAX_FILES=25
+    MAX_LINES=5000
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+FILE_COUNT=$(find "$PHASE_PATH" -maxdepth 2 -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+TOTAL_LINES=$(find "$PHASE_PATH" -maxdepth 2 -name "*.md" -type f -exec cat {} \; 2>/dev/null | wc -l | tr -d ' ')
+
+OVER_FILES=0
+OVER_LINES=0
+[ "$FILE_COUNT" -gt "$MAX_FILES" ] && OVER_FILES=1
+[ "$TOTAL_LINES" -gt "$MAX_LINES" ] && OVER_LINES=1
+
+if [ "$OVER_FILES" -eq 0 ] && [ "$OVER_LINES" -eq 0 ]; then
+  exit 0
+fi
+
+cat <<EOF
+Output mode violation — agent "${AGENT}" exceeded the budget for project_size="${MODE}".
+
+Phase directory: ${PHASE_PATH}
+Files emitted:   ${FILE_COUNT} (budget: ${MAX_FILES})
+Total lines:     ${TOTAL_LINES} (budget: ${MAX_LINES})
+
+Per gsp/policies/output-modes.md, "${MODE}" mode requires consolidated output. Ask the agent to:
+1. Consolidate the per-chunk files into a single ${PHASE_DIR}/PHASE.md with H2 sections matching the chunk vocabulary
+2. Delete the redundant chunk files
+3. Update ${PHASE_DIR}/INDEX.md to reflect the consolidated structure
+
+Skip-if-not-present: omit sections that have no real content for this project. Do not pad.
+EOF
+
+exit 1


### PR DESCRIPTION
## Summary

- Three output modes (`chat` / `compact` / `full`) for the **project pipeline**, defaulting to `compact`. The chunk-per-axis structure becomes opt-in.
- Brand pipeline stays full fidelity always — confirmed via empirical verification it's a solid foundation for any project size.
- Designer-readable vocabulary preserved across all modes (Personas, IA, Component Spec, Microcopy, Accessibility, Visual Design, etc.) — modes change file partitioning, not language.
- `SubagentStop` hook enforces budgets per the adversarial finding that prompt-only fixes don't reliably change agent behavior.

## What changes

| File | Change |
|---|---|
| `gsp/policies/output-modes.md` *(NEW)* | Single source of truth: per-mode chunk counts, skip-if-not-present doctrine, interaction matrix with existing scope axes |
| `scripts/check-artifact-size.sh` *(NEW)* | `SubagentStop` hook that reads `project_size` and rejects over-budget output |
| `gsp/hooks/hooks.json` | Registers the hook for 6 project-pipeline agents (researcher entry added; rest get the command hook alongside their existing prompt hook) |
| `gsp/templates/projects/config.json` | Adds `project_size: "compact"` default |
| `gsp/skills/gsp-start/SKILL.md` | Step 2.5 asks mode before routing to project flows (skipped for brand-only flows) |
| 6 × `gsp-project-*/SKILL.md` | Cite policy in `<objective>` block |
| 6 × `methodology/gsp-project-*.md` | `<persistence>` block with skip-if-not-present examples |

## Why

Per #211, focused projects today produce 7-8× planning-to-code ratio (44 files / 7,852 lines for ~1,000 LOC of actual code). The chunk-per-axis structure is sized for multi-screen new-app work but runs unconditionally on every project size.

Approach went through three iterations:
1. **v1 (auto-detect from brief signals)** — killed by adversarial review (signals are unknowable at brief-time; agents reliably ignore prompt guidance).
2. **v2 (size-policy.md + hook)** — sound but missed Impeccable's "ephemeral-by-default" lesson.
3. **v3 (user-declared mode + skip-if-not-present + hook enforcement)** — incorporates Impeccable's compact-vs-full doctrine and the verified-solid brand pipeline as the foundation. Shipped.

## Test plan

- [x] `dev/scripts/audit-tests.sh`: 73 PASS · 2 WARN (pre-existing) · 0 FAIL
- [x] `scripts/check-artifact-size.sh` smoke test across compact/full/chat × under/over-budget cases (5 scenarios, all behave correctly)
- [x] JSON + bash syntax validation
- [ ] Manual: `/gsp-start` → "Design project" → confirm Step 2.5 fires
- [ ] Manual: run `gsp-project-research` agent in compact mode, confirm hook rejects oversized output
- [ ] Follow-up: live `/gspdev-benchmark` capture to measure before/after artifact volume on a real focused project

## Related side-quests filed

Empirical verification of the brand pipeline surfaced three bugs (filed separately, not in this PR):
- #218 — missing `gsp-brand-coherence` agent file
- #219 — no brand-pipeline entry point
- #220 — `/gsp-accessibility --validate` leaves no audit trail

Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)