### PR TITLE
feat: /gsp-polish — detect and fix AI-slop craft failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ plugin/
 test-results/
 tsconfig.tsbuildinfo
 
+# gsp-polish runtime artifacts (safety-wrap orphans if interrupted)
+.polish-stash-ref
+*.polish-backup
+
 # Next.js
 .next/
 out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,8 @@ The filesystem is the integration layer — skills produce artifacts to `.design
 
 | Directory | Contents |
 |-----------|----------|
-| `gsp/skills/` | 35 skills — each is a `gsp-<name>/SKILL.md` directory with optional `domains/` and `references/` siblings |
-| `gsp/agents/` | 12 subagents (`gsp-{name}.md`) |
+| `gsp/skills/` | 36 skills — each is a `gsp-<name>/SKILL.md` directory with optional `domains/` and `references/` siblings |
+| `gsp/agents/` | 13 subagents (`gsp-{name}.md`) |
 | `gsp/hooks/` | Hooks (`hooks.json`) |
 | `gsp/prompts/` | Reserved (agent methodology lives in skill `methodology/` directories) |
 | `gsp/templates/` | Project/brand config, state, brief, roadmap templates |
@@ -94,8 +94,8 @@ Cross-references between skills use `gsp-` prefixed paths: `${CLAUDE_SKILL_DIR}/
 
 | Runtime | Skills location | Agents | Bundle location |
 |---------|-----------------|--------|-----------------|
-| Claude Code | `.claude/skills/` | `.claude/agents/` (12) | `.claude/{prompts,templates}/` |
-| OpenCode | `.opencode/skills/` | `.opencode/agents/` (12) | `.opencode/{prompts,templates}/` |
+| Claude Code | `.claude/skills/` | `.claude/agents/` (13) | `.claude/{prompts,templates}/` |
+| OpenCode | `.opencode/skills/` | `.opencode/agents/` (13) | `.opencode/{prompts,templates}/` |
 | Gemini CLI | `.gemini/skills/` | `.gemini/agents/` (11, experimental) | `.gemini/{prompts,templates}/` |
 | Codex CLI | **`.agents/skills/`** (not `.codex/`) | **None** (not supported) | `.codex/{prompts,templates}/` |
 

--- a/gsp/agents/gsp-polisher.md
+++ b/gsp/agents/gsp-polisher.md
@@ -1,0 +1,17 @@
+---
+name: gsp-polisher
+description: Detects and fixes AI-slop craft failures in React/Tailwind codebases. Spawned by /gsp-polish.
+tools: Read, Write, Edit, Bash, Grep, Glob
+maxTurns: 80
+permissionMode: acceptEdits
+memory: project
+hooks:
+  PostToolUse:
+    - matcher: "Edit|Write"
+      hooks:
+        - type: command
+          command: "${CLAUDE_PROJECT_ROOT}/scripts/lint-check.sh"
+color: magenta
+---
+
+Polishes a codebase by pattern-matching against a craft anti-pattern library. Methodology provided by spawning skill.

--- a/gsp/hooks/hooks.json
+++ b/gsp/hooks/hooks.json
@@ -101,6 +101,15 @@
             "prompt": "The gsp-brand-strategist agent just finished. Verify: (1) strategy/INDEX.md was written, (2) strategy/positioning.md exists, (3) strategy/archetype.md exists, (4) strategy/brand-platform.md exists, (5) strategy/voice-and-tone.md exists, (6) strategy/messaging.md exists. Report any missing deliverables to the user."
           }
         ]
+      },
+      {
+        "matcher": "gsp-polisher",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "The gsp-polisher agent just finished. Verify: (1) polish/findings.md was written, (2) polish/INDEX.md was written. (3) If any safe-auto fixes were applied, verify scripts/polish-safety-wrap.sh was used (look for absence of orphaned .polish-stash-ref files in the project root). (4) Confirm any rolled-back findings appear in polish/findings.md with a rollback-reason. Report any missing deliverables or orphaned stash refs."
+          }
+        ]
       }
     ]
   }

--- a/gsp/skills/gsp-polish/SKILL.md
+++ b/gsp/skills/gsp-polish/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: gsp-polish
+description: Detect and fix AI-slop craft failures in the codebase — scrolling text without fade mask, default chart palettes, lorem placeholders, missing empty states, hardcoded hex outside tokens. Auto-runs after build; user-invocable anytime.
+user-invocable: true
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Edit
+  - Grep
+  - Glob
+  - Agent
+  - AskUserQuestion
+---
+<context>
+Polish phase. Sits between `gsp-project-build` (writes code) and `gsp-project-review` (QA against design). Polish reviews **craft**: the execution-level details that make an agent-built codebase feel "designed" vs "AI slop."
+
+Operates on actual code, not on design specs. Pattern-matches against a curated library of mechanically-detectable anti-patterns. Each pattern is a self-contained file in `patterns/` describing symptom, detection rule, fix, and classification.
+
+Two tiers of fix:
+- **`safe-auto`** — fix is purely additive/reversible (e.g., add `mask-image` className). Applied automatically, wrapped in a git stash safety net + `tsc --noEmit` check; rolled back if either fails.
+- **`propose-diff`** / **`flag-only`** — fix is contextual or requires human input. Surfaced in `polish/proposed-fixes.md` for review.
+
+The skill does **not** overlap with:
+- `gsp-accessibility-audit` (WCAG concerns: focus, contrast, tap targets)
+- `gsp-project-review` (QA against design intent)
+- `gsp-typography` (font choices)
+- `gsp-brand-guidelines` (token system)
+
+If a pattern would catch something those skills own, it's been stripped from this library.
+</context>
+
+<objective>
+Detect and fix craft-level failures in the codebase.
+
+**Input:** Codebase (default scope: `git diff` since HEAD or last polish run) + project config + brand `STYLE.md`
+**Output:** `{project}/polish/` (findings.md, applied-fixes.md, proposed-fixes.md, INDEX.md)
+**Agent:** `gsp-polisher`
+**Output volume:** Honor `skip-if-not-present` doctrine — omit any pattern that returned zero findings. If `preferences.project_size` exists in config, polish writes a single consolidated `polish/PHASE.md` for `compact`; emits the full file set for `full`; returns to chat for `chat`.
+</objective>
+
+<execution_context>
+@${CLAUDE_SKILL_DIR}/patterns/INDEX.yml
+</execution_context>
+
+<rules>
+- Always use `AskUserQuestion` for user interaction — never prompt via plain text.
+- One decision per question — never batch multiple questions in a single message.
+- Never auto-apply a `safe-auto` fix without wrapping in `scripts/polish-safety-wrap.sh` — git stash → apply → tsc check → commit or rollback.
+- Never touch files outside the scope returned by `git diff` unless invoked with `--full`.
+- Respect escape hatches: skip any element with `data-polish-ignore` attribute or preceded by a `{/* polish-ignore */}` comment.
+- Respect brand overrides: each pattern declares which `STYLE.md` keys mute it (e.g., `constraints.never: ["soft-edges"]` mutes `mask-image-on-scrolling-text`).
+- Auto-fix is opt-out via `--no-fix` flag — default is to apply safe-auto.
+- Never modify `node_modules/`, `.next/`, `dist/`, `build/`, or any path matched in `.gitignore`.
+</rules>
+
+<process>
+## Step 0: Parse invocation
+
+| Input | Mode |
+|-------|------|
+| `/gsp-polish` (no args) | Default — scan `git diff`, apply safe-auto, propose review-required |
+| `/gsp-polish --scan` | Scan only — produce findings.md, no fixes |
+| `/gsp-polish --full` | Scan entire project (not just diff) |
+| `/gsp-polish --scope <path>` | Limit scope to a directory or glob |
+| `/gsp-polish --no-fix` | Scan + propose, never auto-apply |
+| `/gsp-polish --pipeline` | Internal — invoked by `gsp-project-build` finalize |
+| `/gsp-polish --list-patterns` | Display the pattern library and exit |
+
+## Step 1: Resolve project context
+
+Resolve project from `.design/projects/` (one → use it, multiple → ask). Set `PROJECT_PATH`.
+
+Read `{PROJECT_PATH}/brand.ref` → set `BRAND_PATH`. If absent, polish runs without brand-override support (logs a warning, but proceeds).
+
+Read `{PROJECT_PATH}/config.json` → get `preferences.project_size` (default `compact`).
+
+Read `{BRAND_PATH}/patterns/STYLE.md` if present — extract `constraints`, `density`, `intensity` for brand-override evaluation.
+
+## Step 2: Stack detection
+
+Glob for `package.json` at project root. Read `dependencies` + `devDependencies`. Polish supports:
+
+- React (`react`)
+- Tailwind CSS (`tailwindcss`)
+- Optional: shadcn/ui (detected by presence of `components/ui/` or `components.json`)
+- Optional: Next.js (`next`)
+
+If React + Tailwind are absent, output: *"Polish targets React + Tailwind codebases. Detected: {stack}. Skipping."* and exit clean.
+
+## Step 3: Determine scope
+
+```bash
+SCOPE_FILES=$(git diff --name-only HEAD -- '*.tsx' '*.jsx' '*.ts' '*.js' '*.mdx' 2>/dev/null \
+  | grep -v -E '(node_modules|\.next|dist|build|\.test\.|\.stories\.)' \
+  | head -200)
+```
+
+For `--full`: replace with `find` over the entire project. For `--scope`: limit to the path. Cap at 200 files per run (perf guardrail).
+
+If `SCOPE_FILES` is empty: output *"No relevant changes. Run /gsp-polish --full to scan the project."* and exit.
+
+## Step 4: Spawn the polisher agent
+
+Spawn `gsp-polisher` agent with this context:
+
+- `SCOPE_FILES` — the file list to scan
+- `PROJECT_PATH` — where to write `polish/` output
+- `BRAND_OVERRIDES` — extracted from STYLE.md (or `{}` if no brand)
+- `OUTPUT_MODE` — chat / compact / full
+- `FIX_MODE` — auto-apply safe-auto, or `--no-fix` flag passed through
+- `PATTERN_LIBRARY` — list of pattern files at `${CLAUDE_SKILL_DIR}/patterns/` (10 entries from INDEX.yml)
+
+The agent reads each pattern file as needed. It does NOT load all 10 into context at once — it iterates and reads on demand.
+
+## Step 5: Agent reports back
+
+After the agent completes, read `polish/findings.md`. Summarize for the user:
+
+```
+  polish — {N} findings, {auto} auto-fixed, {prop} proposed, {flag} flagged
+
+  ─── Auto-fixed ──────────────────
+  ✓ mask-image-on-scrolling-text   3 sites in 2 files
+  ✓ internal-a-not-link            1 site in 1 file
+
+  ─── Proposed (review) ──────────
+  ⚠ transition-all-everywhere     5 sites — see polish/proposed-fixes.md
+
+  ─── Flagged (no auto-fix) ──────
+  ! lorem-and-placeholder-copy    2 sites — copy needs human
+  ! missing-empty-state           1 site — needs design
+
+  next: review polish/proposed-fixes.md or run /gsp-project-build to apply.
+```
+
+If the safety wrap rolled back any auto-fix (tsc failure), it appears as flagged with `rollback-reason: tsc-error`.
+
+## Step 6: Pipeline integration
+
+When invoked with `--pipeline` flag (from `gsp-project-build` finalize), polish runs silently — no user prompts, all fixes auto-applied where classification permits, output written to `polish/`. Build's BUILD-LOG.md gets a single line: `Polish: {N} findings, {auto} applied`.
+
+For other modes (manual user invocation), Step 5's summary is shown.
+</process>
+
+<patterns_library_summary>
+| Pattern | Tier | Rationale |
+|---|---|---|
+| `mask-image-on-scrolling-text` | safe-auto | Pure className addition; reversible |
+| `default-recharts-palette` | safe-auto | Token swap, only fires if chart tokens defined in globals.css |
+| `mobile-text-no-clamp` | safe-auto | Adds `text-balance` + responsive ramp |
+| `internal-a-not-link` | safe-auto | Mechanical `<a>` → `<Link>` rewrite for internal hrefs |
+| `image-fill-no-relative-parent` | safe-auto | Adds `relative` to parent + `aspect-*` ratio |
+| `transition-all-everywhere` | propose-diff | Target property is contextual |
+| `lorem-and-placeholder-copy` | flag-only | Copy needs human |
+| `generic-loading-text` | flag-only | Skeleton shape is contextual |
+| `missing-empty-state` | flag-only | Copy + design needed |
+| `raw-hex-colors-outside-tokens` | flag-only | Slop tell; token swap may ripple |
+</patterns_library_summary>

--- a/gsp/skills/gsp-polish/methodology/gsp-polisher.md
+++ b/gsp/skills/gsp-polish/methodology/gsp-polisher.md
@@ -1,0 +1,119 @@
+<role>
+You are a GSP polisher spawned by `/gsp-polish`. Act as a Senior Design Engineer with a craft obsession — the kind that notices a scrolling list with no fade, a chart with default purple, a button with `transition-all`, and fixes it before review.
+
+You don't audit accessibility (that's `gsp-accessibility-auditor`). You don't review against design intent (that's `gsp-project-reviewer`). You audit **craft**: the execution-level details that make a codebase feel designed, not generated.
+
+You are given a curated library of 10 anti-patterns. Each pattern is a self-contained `.md` file describing symptom, detection rule, fix, classification (`safe-auto` / `propose-diff` / `flag-only`), and brand-override schema.
+</role>
+
+<persistence>
+**Skip-if-not-present:** if a pattern returns zero findings for the current scope, omit it from the output. Don't list "0 findings" entries.
+
+If `preferences.project_size` is set in the project config: honor `chat | compact | full` as defined in `gsp/policies/output-modes.md` (when present). Otherwise default to writing the four chunked files: `polish/findings.md`, `polish/applied-fixes.md`, `polish/proposed-fixes.md`, `polish/INDEX.md`.
+</persistence>
+
+<methodology>
+## Step 0: Load pattern library
+
+Read `patterns/INDEX.yml` — a list of 10 patterns with `name`, `file`, `tier`, `severity`.
+
+Do NOT read all 10 pattern files upfront. Iterate one at a time; for each, read its `.md` only when you're about to run its detection.
+
+## Step 1: Read brand context
+
+If `BRAND_OVERRIDES` was passed by the spawning skill, internalize:
+- `constraints.never` — patterns matching these keys mute the corresponding rule
+- `constraints.always` — patterns matching these keys are guaranteed to fire (raise severity)
+- `density: tight|normal|loose` — affects spacing-sensitive patterns
+- `intensity.variance / motion / density` — affects motion + layout patterns
+
+Each pattern's frontmatter declares a `brand-override:` block listing which STYLE.md keys mute it. If a mute key matches, skip the pattern entirely.
+
+## Step 2: Iterate patterns
+
+For each pattern in INDEX.yml:
+
+1. **Read the pattern file** (`patterns/{name}.md`)
+2. **Check brand-override** — if any `mute-when` key matches `BRAND_OVERRIDES`, skip
+3. **Run detection** — apply the pattern's grep/AST rule against `SCOPE_FILES`
+4. **Filter escape hatches** — skip any match where the element has `data-polish-ignore` attribute OR is preceded (within 3 lines) by a `{/* polish-ignore */}` or `<!-- polish-ignore -->` comment
+5. **Classify each finding** by the pattern's tier:
+   - `safe-auto` → queue for atomic fix application
+   - `propose-diff` → generate before/after diff, queue for proposed-fixes.md
+   - `flag-only` → record in findings.md with rationale, no fix
+
+## Step 3: Apply safe-auto fixes (atomic)
+
+Group all safe-auto findings by file. For each file:
+
+1. Call `bash ${CLAUDE_PROJECT_ROOT}/scripts/polish-safety-wrap.sh begin {file-path}` — this creates a git stash checkpoint of the file
+2. Apply all safe-auto fixes for that file via `Edit` (one Edit per finding)
+3. Call `bash ${CLAUDE_PROJECT_ROOT}/scripts/polish-safety-wrap.sh check` — runs `tsc --noEmit` on the project
+4. If tsc passes: `bash ${CLAUDE_PROJECT_ROOT}/scripts/polish-safety-wrap.sh commit` — drops the stash
+5. If tsc fails: `bash ${CLAUDE_PROJECT_ROOT}/scripts/polish-safety-wrap.sh rollback` — restores the stash; demote all that file's safe-auto findings to `proposed-fixes.md` with `rollback-reason: tsc-error`
+
+Per-file atomicity: a tsc failure rolls back only the failing file, not the whole run.
+
+## Step 4: Generate proposed diffs
+
+For each `propose-diff` finding:
+
+1. Read the file
+2. Generate a before/after snippet (max 30 lines of context)
+3. Write into `polish/proposed-fixes.md` with:
+   - File + line
+   - Pattern name + severity
+   - Why this matters (1-2 sentences)
+   - Before / After code blocks
+   - Brand context (e.g., "STYLE.md density is `tight`; the responsive ramp respects this")
+
+User can apply these manually or via a follow-up `/gsp-project-build`.
+
+## Step 5: Write findings.md
+
+Structure:
+
+```markdown
+# Polish findings — {project} — {timestamp}
+
+Scanned {N} files. Found {total} issues across {patterns} patterns.
+
+## Auto-fixed ({auto-count})
+- `{pattern-name}` — {N} sites in {M} files (see applied-fixes.md)
+
+## Proposed (review required) ({proposed-count})
+- `{pattern-name}` — {N} sites → polish/proposed-fixes.md#{anchor}
+
+## Flagged (no auto-fix) ({flag-count})
+- `{pattern-name}` — {N} sites
+  - {file:line} — {brief context}
+
+## Skipped (brand-override)
+- `{pattern-name}` — muted by STYLE.md `{key}: {value}`
+```
+
+## Step 6: Write INDEX.md
+
+Standard chunk index pointing at findings.md / proposed-fixes.md / applied-fixes.md (whichever exist for the current output mode).
+
+## Pattern detection notes
+
+- **Default scope is git diff**, not full project. The skill body has already filtered to relevant files.
+- **shadcn-composed components** — if a className resolves through `cn()`, `cva()`, or `buttonVariants()`, prefer reading the variant definition than grepping the call site. False-positive avoidance.
+- **CSS-in-JS / @layer** — patterns that target Tailwind classes won't catch styles defined in `@layer components`. That's fine — those styles are intentional system patterns.
+- **Test files / stories** — already filtered out by the skill body. Don't second-guess.
+
+## What you do NOT do
+
+- Don't review against design intent (that's review's job)
+- Don't audit accessibility (that's accessibility-audit's job)
+- Don't reformulate the brand (that's brand-refine's job)
+- Don't add patterns to the library unilaterally — that's an explicit user action
+
+## Output quality bar
+
+- Each finding has a precise file:line citation
+- Each `propose-diff` has a real before/after that compiles
+- `flag-only` findings include enough context for a human to decide (not just "fix this")
+- Don't pad. If you found 2 issues, report 2 issues. Skip-if-not-present applies.
+</methodology>

--- a/gsp/skills/gsp-polish/patterns/INDEX.yml
+++ b/gsp/skills/gsp-polish/patterns/INDEX.yml
@@ -1,0 +1,77 @@
+# GSP Polish — Pattern Library
+# 10 mechanically-detectable craft failures in React/Tailwind/(shadcn) codebases
+# Each pattern is a self-contained .md file. Adding a pattern = drop a file here.
+
+patterns:
+  # ── Safe-auto (additive, reversible, guarded by tsc check) ────────────────
+  - name: mask-image-on-scrolling-text
+    file: mask-image-on-scrolling-text.md
+    tier: safe-auto
+    severity: low
+    category: scroll
+    vibe: "Scrolling text hard-clips at the edge — add a fade mask"
+
+  - name: default-recharts-palette
+    file: default-recharts-palette.md
+    tier: safe-auto
+    severity: medium
+    category: data-viz
+    vibe: "Charts use Recharts' default purple/green — swap for brand tokens"
+
+  - name: mobile-text-no-clamp
+    file: mobile-text-no-clamp.md
+    tier: safe-auto
+    severity: low
+    category: typography
+    vibe: "Hero text is fixed text-6xl — add responsive ramp + text-balance"
+
+  - name: internal-a-not-link
+    file: internal-a-not-link.md
+    tier: safe-auto
+    severity: medium
+    category: nextjs
+    vibe: "Internal href uses <a> not next/link — losing prefetch + client-side nav"
+
+  - name: image-fill-no-relative-parent
+    file: image-fill-no-relative-parent.md
+    tier: safe-auto
+    severity: medium
+    category: nextjs
+    vibe: "next/image with fill but parent isn't positioned — image will collapse"
+
+  # ── Propose-diff (contextual; user reviews before apply) ──────────────────
+  - name: transition-all-everywhere
+    file: transition-all-everywhere.md
+    tier: propose-diff
+    severity: medium
+    category: animation
+    vibe: "transition-all animates everything including layout — pick a property"
+
+  # ── Flag-only (no auto fix; human input required) ─────────────────────────
+  - name: lorem-and-placeholder-copy
+    file: lorem-and-placeholder-copy.md
+    tier: flag-only
+    severity: high
+    category: copy
+    vibe: "Lorem ipsum / John Doe / Click here shipped to prod"
+
+  - name: generic-loading-text
+    file: generic-loading-text.md
+    tier: flag-only
+    severity: medium
+    category: states
+    vibe: "Loading... text where a skeleton should be"
+
+  - name: missing-empty-state
+    file: missing-empty-state.md
+    tier: flag-only
+    severity: medium
+    category: states
+    vibe: "List renders nothing on empty array — no empty state"
+
+  - name: raw-hex-colors-outside-tokens
+    file: raw-hex-colors-outside-tokens.md
+    tier: flag-only
+    severity: high
+    category: tokens
+    vibe: "Raw hex values in className or style — bypasses the token system"

--- a/gsp/skills/gsp-polish/patterns/default-recharts-palette.md
+++ b/gsp/skills/gsp-polish/patterns/default-recharts-palette.md
@@ -1,0 +1,76 @@
+---
+name: default-recharts-palette
+tier: safe-auto
+severity: medium
+category: data-viz
+brand-override:
+  mute-when:
+    - "constraints.never includes 'brand-tokens-in-charts'"
+preconditions:
+  # Pattern only fires if chart tokens exist in globals.css. Otherwise downgrades to propose-diff.
+  - "globals.css OR app.css OR styles/globals.css contains --chart-1"
+references:
+  - https://ui.shadcn.com/docs/components/chart
+  - https://recharts.org/en-US/api
+---
+
+# Symptom
+
+Charts render with Recharts' default `#8884d8` (purple) and `#82ca9d` (green). Instant "AI app" tell — every AI-built dashboard looks the same.
+
+# Detection
+
+Scope: `.tsx`, `.jsx` files.
+
+Grep for any of:
+- `#8884d8` (Recharts default primary)
+- `#82ca9d` (Recharts default secondary)
+- `stroke="#8884d8"`
+- `fill="#8884d8"`
+- `stroke="#82ca9d"`
+- `fill="#82ca9d"`
+
+Also flag any Recharts component (`<LineChart>`, `<BarChart>`, `<AreaChart>`, `<PieChart>`, `<Line>`, `<Bar>`, `<Area>`, `<Pie>`, `<Cell>`) with NO `stroke=` or `fill=` prop (uses default).
+
+```bash
+grep -nE '(#8884d8|#82ca9d)' "$file"
+grep -nE '<(Line|Bar|Area|Pie|Cell)(Chart)?( [^>]+)?>' "$file" | grep -v -E '(stroke=|fill=)'
+```
+
+# Precondition check (CRITICAL)
+
+Before auto-applying, verify the project has shadcn chart tokens defined:
+
+```bash
+grep -lE '\-\-chart-1\s*:' app/globals.css src/globals.css styles/globals.css src/index.css 2>/dev/null
+```
+
+If NO file matches → demote this pattern to `propose-diff` for the current run. Auto-applying `var(--chart-1)` when the token is undefined writes broken CSS.
+
+# Fix
+
+Replace hex with shadcn chart token. Cycle through tokens 1-5 in order of appearance.
+
+**Before:**
+```tsx
+<Line type="monotone" dataKey="revenue" stroke="#8884d8" />
+<Line type="monotone" dataKey="cost" stroke="#82ca9d" />
+```
+
+**After:**
+```tsx
+<Line type="monotone" dataKey="revenue" stroke="var(--chart-1)" />
+<Line type="monotone" dataKey="cost" stroke="var(--chart-2)" />
+```
+
+For unset Recharts components (no `stroke`/`fill`), add `stroke="var(--chart-1)"` to the first, increment for siblings.
+
+# Why
+
+Charts are one of the most visible "AI app" tells. Brand tokens make the chart feel like part of the design system instead of an island.
+
+# Edge cases (do not fire)
+
+- **Visx, D3, Tremor users** — the pattern targets Recharts specifically. Other libs have their own theming model.
+- **Demo / fixture files** — paths matching `*.stories.*` are already filtered.
+- **Chart in `@/components/ui/chart`** — shadcn's chart primitive. Has its own theming. Skip.

--- a/gsp/skills/gsp-polish/patterns/generic-loading-text.md
+++ b/gsp/skills/gsp-polish/patterns/generic-loading-text.md
@@ -1,0 +1,77 @@
+---
+name: generic-loading-text
+tier: flag-only
+severity: medium
+category: states
+brand-override:
+  mute-when:
+    - "constraints.always includes 'text-loading-indicators'"
+references:
+  - https://ui.shadcn.com/docs/components/skeleton
+  - https://www.nngroup.com/articles/progress-indicators/
+---
+
+# Symptom
+
+`<div>Loading...</div>` or `<p>Loading</p>` rendered while data fetches. Causes content jump when data arrives (text disappears, real content takes its place at different dimensions).
+
+# Detection
+
+Scope: `.tsx`, `.jsx`.
+
+Grep for JSX text children matching:
+
+```regex
+>Loading\.{0,3}<|>Loading<|>Fetching\.{0,3}<|>Please wait\.{0,3}<
+```
+
+Also flag isolated `<Spinner />`, `<Loader />`, `<LoadingSpinner />` NOT wrapped in a skeleton-shaped container (no sibling `<Skeleton>` or shape-matching div).
+
+```bash
+grep -nE '>(Loading|Fetching|Please wait)\.{0,3}<' "$file"
+grep -nE '<(Spinner|Loader|LoadingSpinner)( /| ?>)' "$file"
+```
+
+# Why this is flag-only
+
+The right replacement is a skeleton block sized to the eventual content — but the polisher can't see what the content will look like. Suggesting a skeleton shape would be guessing.
+
+# Fix (manual)
+
+Replace with shadcn `<Skeleton>` shaped like the loaded content:
+
+**Before:**
+```tsx
+{isLoading ? <div>Loading...</div> : <UserCard user={user} />}
+```
+
+**After:**
+```tsx
+{isLoading ? (
+  <div className="space-y-2">
+    <Skeleton className="h-4 w-1/3" />
+    <Skeleton className="h-3 w-2/3" />
+    <Skeleton className="h-3 w-1/2" />
+  </div>
+) : (
+  <UserCard user={user} />
+)}
+```
+
+Polish reports findings as:
+
+```
+- {file}:{line} — "Loading..." text indicator
+  surrounding JSX: {opening tag of nearest sibling component}
+  suggestion: replace with <Skeleton /> shaped like {component-name}
+```
+
+# Edge cases (do not fire)
+
+- **Loading text inside a button** (`<Button>Loading...</Button>`) — button label can legitimately say "Loading" while disabled
+- **Inline loading states for very small UI** — a 1-line "Loading..." in a status bar is fine; don't fire unless the loading state lasts >2s OR replaces a non-trivial component
+- **Brand explicitly allows text loaders** — `constraints.always: [text-loading-indicators]` mutes
+
+# Heuristic for severity
+
+If the spinner is inside a full-page container (`<main>`, `<section className="min-h-screen">`), severity = high. If inline (small status), severity = low.

--- a/gsp/skills/gsp-polish/patterns/image-fill-no-relative-parent.md
+++ b/gsp/skills/gsp-polish/patterns/image-fill-no-relative-parent.md
@@ -1,0 +1,62 @@
+---
+name: image-fill-no-relative-parent
+tier: safe-auto
+severity: medium
+category: nextjs
+brand-override:
+  mute-when: []
+preconditions:
+  - "package.json contains 'next' in dependencies"
+references:
+  - https://nextjs.org/docs/app/api-reference/components/image#fill
+---
+
+# Symptom
+
+`<Image fill />` from `next/image` requires a positioned parent (`relative`, `absolute`, or `fixed`). When the parent is the default `static`, the image collapses to zero height — invisible bug, no error.
+
+# Detection
+
+Scope: `.tsx`, `.jsx` in a Next.js project (precondition).
+
+AST/regex: find every `<Image ...fill...>` (from `next/image`). Walk up the JSX tree to its direct parent element. If parent's className does NOT contain `relative`, `absolute`, or `fixed`, fire.
+
+```bash
+# Conservative grep — match Image with fill, then capture preceding <div> opening tag
+grep -nB 1 '<Image[^>]*\bfill\b' "$file" \
+  | grep -A 1 -E '<(div|section|article|main|aside)' \
+  | grep -v -E '(relative|absolute|fixed)'
+```
+
+(Real implementation should use JSX AST to reliably find the parent — grep is approximate.)
+
+# Fix
+
+Add `relative` to parent className. If the parent has no className attribute, add one. If the parent has no explicit aspect ratio, prompt the user (downgrade to `propose-diff` for this finding).
+
+**Before:**
+```tsx
+<div className="w-full">
+  <Image src="/hero.jpg" alt="..." fill />
+</div>
+```
+
+**After:**
+```tsx
+<div className="w-full relative aspect-[16/9]">
+  <Image src="/hero.jpg" alt="..." fill />
+</div>
+```
+
+Aspect ratio default: `aspect-[16/9]` for hero-like images. **If the user can't predict the aspect ratio, demote to propose-diff** with a comment explaining the choice.
+
+# Why
+
+`fill` makes the image absolutely position itself to fill the parent. Without `relative` (or `absolute`/`fixed`), the parent doesn't constrain the image — it renders at 0×0. This is a silent bug that doesn't fail builds or tests.
+
+# Edge cases (do not fire)
+
+- **Parent already has `relative` / `absolute` / `fixed`** — pattern doesn't fire
+- **`fill` is conditional** (`<Image {...(condition ? {fill: true} : {width, height})} />`) — too risky; skip
+- **Parent is a known sized component** (e.g., shadcn `<AspectRatio>`) — already provides positioning; skip
+- **Parent className uses CVA** — can't statically resolve; demote to flag-only

--- a/gsp/skills/gsp-polish/patterns/internal-a-not-link.md
+++ b/gsp/skills/gsp-polish/patterns/internal-a-not-link.md
@@ -1,0 +1,74 @@
+---
+name: internal-a-not-link
+tier: safe-auto
+severity: medium
+category: nextjs
+brand-override:
+  mute-when: []  # no brand reason to use raw <a> for internal nav
+preconditions:
+  - "package.json contains 'next' in dependencies"
+references:
+  - https://nextjs.org/docs/app/api-reference/components/link
+---
+
+# Symptom
+
+`<a href="/dashboard">` used for internal routes in a Next.js app. Loses prefetch, full page reload on click, no client-side navigation.
+
+# Detection
+
+Scope: `.tsx`, `.jsx` files in a Next.js project (precondition).
+
+Grep for `<a href="/...">` where:
+- href starts with `/` (internal route, not `/_next/` or absolute external)
+- href does NOT start with `/api/` (API routes legitimately use raw `<a>` for downloads)
+- the element is not preceded by an `<a download` attribute
+- the element does not have `target="_blank"` (external opens)
+
+```bash
+grep -nE '<a href="/[^/"]' "$file" \
+  | grep -v -E '(target="_blank"|/api/|download)'
+```
+
+# Fix
+
+Rewrite as Next.js `<Link>`. Add the import if not present.
+
+**Before:**
+```tsx
+<a href="/dashboard" className="text-foreground hover:underline">
+  Dashboard
+</a>
+```
+
+**After:**
+```tsx
+import Link from "next/link";
+
+<Link href="/dashboard" className="text-foreground hover:underline">
+  Dashboard
+</Link>
+```
+
+The Edit operation must:
+1. If `import Link from "next/link"` is not already in the file's imports, add it (alphabetical with other "next/" imports)
+2. Replace `<a href="..."` with `<Link href="..."`
+3. Replace closing `</a>` with `</Link>` (only the matching one — use line-aware matching)
+
+# Why
+
+`next/link` enables:
+- **Prefetch** on viewport entry — perceived performance jump
+- **Client-side navigation** — no full reload, preserves state, preserves scroll
+- **Automatic route checking** — TypeScript can catch bad hrefs
+
+The fix is mechanical and universally beneficial for internal routes.
+
+# Edge cases (do not fire)
+
+- **External links** — `target="_blank"` already present → leave alone
+- **Download links** — `download` attribute present → leave alone
+- **Anchor scrolls** — href starts with `#` → not an internal route, leave alone
+- **API routes** — `/api/*` paths often serve files; leave as `<a>`
+- **mailto: / tel:** — not `/`-prefixed; not caught by detection
+- **Dynamic href from props** — `<a href={url}>` — can't know if internal/external statically; skip

--- a/gsp/skills/gsp-polish/patterns/lorem-and-placeholder-copy.md
+++ b/gsp/skills/gsp-polish/patterns/lorem-and-placeholder-copy.md
@@ -1,0 +1,64 @@
+---
+name: lorem-and-placeholder-copy
+tier: flag-only
+severity: high
+category: copy
+brand-override:
+  mute-when: []  # no brand allows lorem ipsum in prod
+references:
+  - https://www.nngroup.com/articles/microcontent-how-to-write-headlines-page-titles-and-subject-lines/
+---
+
+# Symptom
+
+Lorem ipsum, generic names ("John Doe"), "Click here", "Acme Inc", `example@email.com` — placeholder copy that survived from scaffolding into production code.
+
+# Detection
+
+Scope: `.tsx`, `.jsx`, `.mdx`, `.md`. EXCLUDES files matching:
+- `*.stories.*`
+- `*.test.*`, `*.spec.*`
+- `_*` (Storybook docs prefix)
+- `*.fixture.*`
+
+Regex (case-insensitive):
+
+```regex
+(lorem ipsum|Lorem\b|John Doe|Jane Doe|jane@example\.|john@example\.|Click here|Acme( Inc| Corp)?|Foo Bar|placeholder text|Sample text|user@example\.)
+```
+
+```bash
+grep -niE '(lorem ipsum|Lorem\b|John Doe|Jane Doe|jane@example\.|john@example\.|Click here|Acme( Inc| Corp)?|Foo Bar)' "$file"
+```
+
+# Why this is flag-only
+
+Copy can't be mechanically rewritten. The replacement depends on:
+- Brand voice (`STYLE.md` voice constraints)
+- The actual product (what should "John Doe" be replaced with? Real placeholder names? A demo user with character?)
+- Context (button label vs. body text vs. avatar name)
+
+# Fix (manual or via brand-strategy skill)
+
+For each finding, the user (or `gsp-brand-strategy` voice guidelines) should:
+
+1. Determine the role of the placeholder (CTA, demo data, microcopy, etc.)
+2. Replace with brand-appropriate copy
+3. If demo data — consider extracting to a `lib/demo-data.ts` so it's at least clearly fixture-shaped
+
+Polish reports findings as:
+
+```
+- {file}:{line} — "{matched text}" — placeholder copy
+  context: {30 chars before/after}
+  classification: {cta|demo-data|microcopy|body|other}
+```
+
+The `classification` is heuristic based on surrounding JSX (e.g., inside `<Button>` → cta; inside `<Avatar>` `alt=` → demo-data; in body text → body).
+
+# Edge cases (do not fire)
+
+- **Storybook / test files** — already excluded
+- **Comments** — `// John Doe is a placeholder` — code comments aren't user-visible. Detection should exclude lines starting with `//` or inside `/* */` blocks.
+- **String literals in lib/ utilities clearly named as fixtures** — `export const FIXTURE_USER = "John Doe"` — too ambiguous to auto-skip; flag and let user decide.
+- **i18n keys** — `t("john_doe_demo_label")` — the key is conventional, not user-facing copy.

--- a/gsp/skills/gsp-polish/patterns/mask-image-on-scrolling-text.md
+++ b/gsp/skills/gsp-polish/patterns/mask-image-on-scrolling-text.md
@@ -1,0 +1,69 @@
+---
+name: mask-image-on-scrolling-text
+tier: safe-auto
+severity: low
+category: scroll
+brand-override:
+  mute-when:
+    - "constraints.never includes 'soft-edges'"
+    - "constraints.never includes 'fade-masks'"
+    - "intensity.variance == 0 AND density == tight"  # hard-edged design language
+references:
+  - https://tailwindcss.com/docs/mask-image
+  - https://web.dev/articles/scroll-behavior
+---
+
+# Symptom
+
+A scrollable container clips its content at the edge with a jagged cutoff. The user can see text being "sliced" mid-line, which both reads as cheap and obscures whether there's more content.
+
+# Detection
+
+Scope: `.tsx`, `.jsx` files.
+
+Grep for elements where className contains BOTH:
+- `overflow-y-auto` OR `overflow-y-scroll` OR `overflow-auto` OR `overflow-scroll`
+- `max-h-` OR `h-[`
+
+AND the className does NOT contain:
+- `mask-image`
+- `[mask-image:`
+- `[mask:` (shorthand)
+
+AND no immediate JSX child has className with `absolute` + `bg-gradient-to-(t|b)` (manual fade overlay).
+
+```bash
+grep -nE 'className="[^"]*overflow-y-(auto|scroll|hidden)[^"]*"' "$file" \
+  | grep -E '(max-h-|h-\[)' \
+  | grep -v -E '(mask-image|\[mask)'
+```
+
+# Fix
+
+Add `mask-image` className modifier. The fade size is fixed at 12px (subtle, brand-neutral).
+
+**Before:**
+```tsx
+<div className="overflow-y-auto max-h-64 space-y-2">
+  {items.map(...)}
+</div>
+```
+
+**After:**
+```tsx
+<div className="overflow-y-auto max-h-64 space-y-2 [mask-image:linear-gradient(to_bottom,transparent,black_12px,black_calc(100%-12px),transparent)]">
+  {items.map(...)}
+</div>
+```
+
+For horizontal scrolls (`overflow-x-*`), use `to_right` with the same gradient stops.
+
+# Why
+
+A soft fade signals "there's more content" without making the user scroll to confirm. Hard cutoffs read as a rendering bug. The fix is purely additive: removing it leaves the original behavior, so it's safe to auto-apply.
+
+# Edge cases (do not fire)
+
+- **Intentional hard-edge containers** — kanban columns, modals, code blocks. Mute these by adding `data-polish-ignore` to the element OR by setting `constraints.never: [soft-edges]` in STYLE.md.
+- **shadcn ScrollArea** — already handles its own indicator. If the element is `<ScrollArea>` from `@/components/ui/scroll-area`, skip.
+- **Tab panels with explicit overflow design** — Mute via `data-polish-ignore`.

--- a/gsp/skills/gsp-polish/patterns/missing-empty-state.md
+++ b/gsp/skills/gsp-polish/patterns/missing-empty-state.md
@@ -1,0 +1,91 @@
+---
+name: missing-empty-state
+tier: flag-only
+severity: medium
+category: states
+brand-override:
+  mute-when: []
+references:
+  - https://www.nngroup.com/articles/empty-state-interface-design/
+  - https://ui.shadcn.com/docs/components/card
+---
+
+# Symptom
+
+A list or table renders nothing when its source array is empty. User sees a blank region — no illustration, no helpful CTA, no explanation of how to add the first item.
+
+# Detection
+
+Scope: `.tsx`, `.jsx`.
+
+AST: find every `.map(` call producing JSX. For each, check whether the same component has:
+- A `length === 0` conditional referencing the same array
+- A `!array.length` short-circuit
+- A `array?.length` check returning fallback JSX
+
+If NONE of these guard the empty case, fire.
+
+```bash
+# Conservative grep — finds .map() calls
+grep -nE '\.map\(\s*\([^)]*\)\s*=>' "$file"
+# Then per-finding: check the surrounding component for empty-guards
+grep -nE '(length === 0|length == 0|!.{1,20}\.length|\.length\s*\?)' "$file"
+```
+
+If a file has `.map()` calls and the component has no length-zero branches at all, flag every `.map()` in the component.
+
+# Why this is flag-only
+
+The empty state requires:
+- Brand-appropriate microcopy ("No invoices yet" vs "Nothing to see here" vs "Get started by adding your first invoice")
+- An optional illustration / icon
+- A CTA matching the user's mental model
+- Layout that doesn't shift when content arrives
+
+None of these are mechanically derivable. Surface and let a human (or `gsp-brand-strategy`) write it.
+
+# Fix (manual scaffold)
+
+Polish suggests the scaffold; user fills in the content:
+
+**Before:**
+```tsx
+<ul>
+  {invoices.map(inv => <InvoiceRow key={inv.id} invoice={inv} />)}
+</ul>
+```
+
+**After:**
+```tsx
+{invoices.length === 0 ? (
+  <EmptyState
+    icon={<FileText />}
+    title="{your-empty-title}"
+    description="{why-empty-and-what-to-do}"
+    action={<Button>{your-cta}</Button>}
+  />
+) : (
+  <ul>
+    {invoices.map(inv => <InvoiceRow key={inv.id} invoice={inv} />)}
+  </ul>
+)}
+```
+
+Polish reports findings as:
+
+```
+- {file}:{line} — .map() over `{arrayName}` with no empty-state guard
+  component: {nearest enclosing function/component name}
+  suggestion: add EmptyState with brand-appropriate copy
+```
+
+# Edge cases (do not fire)
+
+- **Map over enum / static array** — `["a", "b", "c"].map(...)` — never empty, no need for empty state
+- **Map inside another conditional that already guards length** — pattern shouldn't fire if `{condition && array.map(...)}` and `condition` checks array presence
+- **Map nested inside a parent component that handles its own empty state** — heuristic only catches the immediate scope; some false positives expected here. User can flag with `data-polish-ignore` on a wrapper.
+- **Map inside a Storybook file** — already excluded
+
+# Heuristic for severity
+
+If the map renders into a `<main>` or top-level page container, severity = medium. If nested deep in a card/sidebar/widget, severity = low. If the array is fed by a useQuery / SWR (async, likely empty on first load), severity = medium.

--- a/gsp/skills/gsp-polish/patterns/mobile-text-no-clamp.md
+++ b/gsp/skills/gsp-polish/patterns/mobile-text-no-clamp.md
@@ -1,0 +1,65 @@
+---
+name: mobile-text-no-clamp
+tier: safe-auto
+severity: low
+category: typography
+brand-override:
+  mute-when:
+    - "constraints.never includes 'fluid-type'"
+    - "typography.scale == 'static'"  # brand explicitly uses fixed sizes
+references:
+  - https://web.dev/articles/css-text-wrap-balance
+  - https://tailwindcss.com/docs/font-size
+---
+
+# Symptom
+
+Hero/heading uses a fixed `text-6xl` (or larger) with no responsive scale, no `text-balance`, no `text-pretty`. Wraps awkwardly on mobile, orphans on desktop.
+
+# Detection
+
+Scope: `.tsx`, `.jsx`, `.mdx`.
+
+AST/regex: any `<h1>`, `<h2>`, `<h3>` (or shadcn `<Heading>`) where the merged className contains `text-{5xl|6xl|7xl|8xl|9xl}` AND does NOT contain any of:
+- `sm:text-` OR `md:text-` OR `lg:text-` (responsive ramp)
+- `clamp(`
+- `text-balance`
+- `text-pretty`
+
+```bash
+grep -nE '<h[1-3]( [^>]+)?>' "$file" | grep -E 'text-(5xl|6xl|7xl|8xl|9xl)' \
+  | grep -v -E '(sm:text-|md:text-|lg:text-|clamp\(|text-balance|text-pretty)'
+```
+
+# Fix
+
+Add a responsive ramp and `text-balance`. The ramp drops one step on each breakpoint going down.
+
+**Before:**
+```tsx
+<h1 className="text-6xl font-bold">{title}</h1>
+```
+
+**After:**
+```tsx
+<h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-balance">{title}</h1>
+```
+
+Ramp mapping:
+- `text-9xl` → `text-6xl md:text-7xl lg:text-9xl`
+- `text-8xl` → `text-5xl md:text-6xl lg:text-8xl`
+- `text-7xl` → `text-5xl md:text-6xl lg:text-7xl`
+- `text-6xl` → `text-4xl md:text-5xl lg:text-6xl`
+- `text-5xl` → `text-3xl md:text-4xl lg:text-5xl`
+
+Always append `text-balance` if not present.
+
+# Why
+
+Fixed large text breaks on mobile. The fix is mechanical: drop one step per breakpoint going down, and `text-balance` is universally beneficial (no downsides).
+
+# Edge cases (do not fire)
+
+- **Brand declares `typography.scale: static`** — some brands intentionally use one size and let layout breathe. Mute via brand override.
+- **Headings inside a fixed-width container** (e.g., `<aside className="w-64">`) — responsive ramp may overshoot. Check parent width; if narrow, drop one extra step (`text-3xl` instead of `text-4xl`).
+- **Element has `text-balance` or `text-pretty` already** — skip.

--- a/gsp/skills/gsp-polish/patterns/raw-hex-colors-outside-tokens.md
+++ b/gsp/skills/gsp-polish/patterns/raw-hex-colors-outside-tokens.md
@@ -1,0 +1,76 @@
+---
+name: raw-hex-colors-outside-tokens
+tier: flag-only
+severity: high
+category: tokens
+brand-override:
+  mute-when:
+    - "constraints.always includes 'raw-hex-allowed'"
+references:
+  - https://tailwindcss.com/docs/customizing-colors
+  - https://ui.shadcn.com/docs/theming
+---
+
+# Symptom
+
+Raw hex values appear in className arbitrary values (`bg-[#3b82f6]`), `style={{ color: "#fff" }}`, or inline color props. Bypasses the token system — the design system can't theme these.
+
+# Detection
+
+Scope: `.tsx`, `.jsx`, `.mdx`, CSS files.
+
+Grep for hex literals OUTSIDE of:
+- The token definition file (`globals.css`, `tailwind.config.{ts,js}`, `styles/tokens.css`)
+- Comments (`// #ff0000` is fine)
+- String literals that are clearly not colors (e.g., hashes, IDs — but unlikely to look like `#xxx` or `#xxxxxx`)
+
+```bash
+# Find 3-char and 6-char hex literals
+grep -nE '#[0-9a-fA-F]{3,8}(\b|;|\)|"|\s)' "$file" \
+  | grep -v -E '^[^:]+:\s*//' \
+  | grep -vE '(globals\.css|tailwind\.config|tokens\.css)'
+```
+
+Exclusions:
+- Comments (`//`, `/* */`, `<!-- -->`)
+- Lines containing `font-feature-settings`, `id=`, `aria-`, `href=` (likely IDs, not colors)
+- Lines defining the token itself (a hex inside `--something: #...;` in the canonical token files)
+- shadcn/Recharts known-bad hexes — those are caught by `default-recharts-palette` specifically; this pattern catches everything else
+
+# Why this is flag-only
+
+A literal `#3b82f6` could be:
+- A color that should use `var(--primary)` — token swap
+- A color with no matching token — needs a new token added to the system
+- A one-off intentional value (debugging, fixture data) — user's call
+
+Polish can't decide without knowing the token system. Surface and let user choose:
+1. Swap to existing token (if a near-match exists in `STYLE.md` tokens)
+2. Promote to a new token in `globals.css`
+3. Mark as intentional with `// polish-ignore: intentional-raw-hex`
+
+# Fix (manual, brand-aware)
+
+If `STYLE.md` is available, polish includes the closest matching tokens in the finding:
+
+```
+- {file}:{line} — raw hex `#3b82f6` in className "bg-[#3b82f6]"
+  closest tokens (from STYLE.md):
+    - var(--primary)        #2563eb  (Δ 4.2)
+    - var(--accent)         #4f46e5  (Δ 18.1)
+  suggestion: replace with `bg-primary` or define a new token
+```
+
+`Δ` is OKLCH lightness distance — closer = better match.
+
+# Why this matters
+
+Raw hex outside tokens is the #1 "AI generated" tell after default Recharts colors. The brand token system becomes worthless if call sites bypass it. Every raw hex is a brand violation.
+
+# Edge cases (do not fire)
+
+- **Hex inside `globals.css` / `tokens.css`** — that IS the token definition
+- **Hex in a comment** — `// TODO: replace #ff0000` is fine
+- **Hex in a non-color context** — `id="#main"` (CSS selector), `href="#top"` (anchor link) — these are excluded
+- **Brand explicitly allows raw hex** — `constraints.always: [raw-hex-allowed]` mutes (rare but real for some brand systems)
+- **Hex inside a test/story fixture file** — already excluded by scope

--- a/gsp/skills/gsp-polish/patterns/transition-all-everywhere.md
+++ b/gsp/skills/gsp-polish/patterns/transition-all-everywhere.md
@@ -1,0 +1,68 @@
+---
+name: transition-all-everywhere
+tier: propose-diff
+severity: medium
+category: animation
+brand-override:
+  mute-when:
+    - "intensity.motion == 0"  # brand explicitly disables motion
+references:
+  - https://web.dev/articles/animations-guide
+  - https://tailwindcss.com/docs/transition-property
+---
+
+# Symptom
+
+`transition-all` animates every CSS property — including layout-affecting properties like `height`, `display`, `padding`. Causes jank, accidental hover-resize wobble, and layout thrash on properties devs didn't intend to animate.
+
+# Detection
+
+Scope: `.tsx`, `.jsx`.
+
+Grep for `transition-all` anywhere in className strings:
+
+```bash
+grep -nE 'className="[^"]*\btransition-all\b' "$file"
+```
+
+Count per file; flag every instance.
+
+# Fix (per occurrence — contextual)
+
+The right replacement depends on what's actually being animated. Look at sibling pseudo-classes (`hover:`, `focus:`, `active:`, `group-hover:`):
+
+| Sibling classes | Likely intent | Replacement |
+|---|---|---|
+| `hover:bg-`, `hover:text-`, `hover:border-` | Color change | `transition-colors duration-150 ease-out` |
+| `hover:scale-`, `hover:translate-`, `hover:rotate-` | Transform | `transition-transform duration-200 ease-out` |
+| `hover:opacity-`, `group-hover:opacity-` | Fade | `transition-opacity duration-200 ease-out` |
+| Multiple of the above | Mixed | List explicitly: `transition-[colors,transform] duration-150 ease-out` |
+
+**Before:**
+```tsx
+<button className="bg-primary text-primary-foreground transition-all hover:bg-primary/90">
+```
+
+**After:**
+```tsx
+<button className="bg-primary text-primary-foreground transition-colors duration-150 ease-out hover:bg-primary/90">
+```
+
+# Why this is propose-diff, not safe-auto
+
+The target property has to be inferred from sibling classes. The heuristic is decent but not perfect — a developer may intend to animate a property that doesn't appear in `hover:` (e.g., transform animated via state, or `enter:` from `tw-animate-css`). Apply per finding with user review.
+
+# Why this matters
+
+`transition-all` is correlated with:
+- Layout shift on hover (when padding/border changes)
+- Janky animations (browser tries to interpolate non-interpolatable properties)
+- Hidden perf cost (every paint/composite re-evaluates all transitions)
+
+Picking the specific property is a one-line change that fixes all three.
+
+# Edge cases (do not fire)
+
+- **Element uses `tw-animate-css` enter/exit classes** — animation is library-driven; transition-all may be intentional. Demote to flag-only.
+- **Element has `data-state` attributes** (shadcn primitives) — transitions are driven by state changes; user has likely tuned this. Skip.
+- **Brand `intensity.motion == 0`** — motion is muted system-wide. Skip.

--- a/gsp/skills/gsp-project-build/SKILL.md
+++ b/gsp/skills/gsp-project-build/SKILL.md
@@ -430,6 +430,17 @@ Update `{PROJECT_PATH}/STATE.md`:
 - Record completion date
 - Update `## Screen Build Status` table — set Build Status per screen (complete/partial/pending)
 
+### Polish pass
+
+Auto-invoke `/gsp-polish --pipeline` via the Skill tool. Polish scans the `git diff` produced by the build (changed `.tsx`/`.jsx`/`.ts`/`.js` files), applies safe-auto craft fixes wrapped in a git-stash safety net, and writes proposed fixes for review-required findings to `{PROJECT_PATH}/polish/`.
+
+Polish is **opt-out**, not opt-in. If `preferences.skip_polish` is `true` in `config.json`, or the user passed `--skip-polish` to `/gsp-project-build`, skip this step and add a one-line note to BUILD-LOG.md.
+
+After polish completes, append a one-line summary to BUILD-LOG.md:
+```
+Polish: {N} findings, {auto} applied, {prop} proposed, {flag} flagged → see polish/INDEX.md
+```
+
 ### Phase transition output
 
 Invoke `/gsp-phase-transition` with phase `build` and output directory `{PROJECT_PATH}/build/`.

--- a/scripts/polish-safety-wrap.sh
+++ b/scripts/polish-safety-wrap.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# polish-safety-wrap.sh — atomic safety net for /gsp-polish safe-auto fixes.
+#
+# Usage:
+#   polish-safety-wrap.sh begin <file-path>   # backup the file before edits
+#   polish-safety-wrap.sh check               # run tsc --noEmit on the project
+#   polish-safety-wrap.sh commit              # accept the edits (drop backup)
+#   polish-safety-wrap.sh rollback            # restore the backup
+#
+# Each call manages a single per-file backup at <file>.polish-backup, tracked
+# via .polish-stash-ref. Run begin → apply Edits → check → (commit | rollback).
+#
+# Why file-copy instead of git-stash: simpler, works in any git state
+# (worktrees, sparse checkouts, mid-rebase), no interaction with user stashes,
+# atomic on a per-file basis.
+#
+# Zero dependencies beyond cp + Node.js (tsc).
+
+set -euo pipefail
+
+CMD="${1:-}"
+STASH_REF_FILE=".polish-stash-ref"
+
+case "$CMD" in
+  begin)
+    FILE="${2:-}"
+    if [ -z "$FILE" ]; then
+      echo "error: begin requires a file path" >&2
+      exit 2
+    fi
+    if [ ! -f "$FILE" ]; then
+      echo "error: file not found: $FILE" >&2
+      exit 2
+    fi
+    if [ -f "$STASH_REF_FILE" ]; then
+      echo "error: a polish-stash is already in progress (see $STASH_REF_FILE). Run commit or rollback first." >&2
+      exit 2
+    fi
+    BACKUP="${FILE}.polish-backup"
+    if [ -e "$BACKUP" ]; then
+      echo "error: backup file already exists at $BACKUP — refusing to overwrite" >&2
+      exit 2
+    fi
+    cp -p "$FILE" "$BACKUP"
+    echo "$FILE" > "$STASH_REF_FILE"
+    echo "backed up: $FILE → $BACKUP"
+    ;;
+
+  check)
+    if [ ! -f "$STASH_REF_FILE" ]; then
+      echo "error: no active polish backup. Run begin first." >&2
+      exit 2
+    fi
+    # Locate tsconfig.json — if absent, skip TS check (project may be plain JS)
+    TSCONFIG=$(find . -maxdepth 3 -name "tsconfig.json" -not -path "*/node_modules/*" 2>/dev/null | head -n 1)
+    if [ -z "$TSCONFIG" ]; then
+      echo "no tsconfig.json found — skipping TS check"
+      exit 0
+    fi
+    TS_PROJECT_DIR=$(dirname "$TSCONFIG")
+    if [ -x "node_modules/.bin/tsc" ]; then
+      TSC="node_modules/.bin/tsc"
+    elif [ -x "${TS_PROJECT_DIR}/node_modules/.bin/tsc" ]; then
+      TSC="${TS_PROJECT_DIR}/node_modules/.bin/tsc"
+    elif command -v tsc >/dev/null 2>&1; then
+      TSC="tsc"
+    else
+      echo "tsc not found — skipping TS check"
+      exit 0
+    fi
+    (cd "$TS_PROJECT_DIR" && "$TSC" --noEmit --pretty false 2>&1) | tail -n 20
+    EXIT_CODE=${PIPESTATUS[0]}
+    if [ "$EXIT_CODE" -ne 0 ]; then
+      echo "tsc check failed (exit $EXIT_CODE)"
+      exit 1
+    fi
+    echo "tsc check passed"
+    ;;
+
+  commit)
+    if [ ! -f "$STASH_REF_FILE" ]; then
+      echo "error: no active polish backup. Run begin first." >&2
+      exit 2
+    fi
+    FILE=$(head -n 1 "$STASH_REF_FILE")
+    BACKUP="${FILE}.polish-backup"
+    rm -f "$BACKUP"
+    rm -f "$STASH_REF_FILE"
+    echo "polish committed; backup dropped"
+    ;;
+
+  rollback)
+    if [ ! -f "$STASH_REF_FILE" ]; then
+      echo "error: no active polish backup. Run begin first." >&2
+      exit 2
+    fi
+    FILE=$(head -n 1 "$STASH_REF_FILE")
+    BACKUP="${FILE}.polish-backup"
+    if [ -f "$BACKUP" ]; then
+      mv -f "$BACKUP" "$FILE"
+    else
+      echo "warning: backup file missing — file not restored" >&2
+    fi
+    rm -f "$STASH_REF_FILE"
+    echo "polish rolled back: $FILE restored"
+    ;;
+
+  *)
+    echo "usage: polish-safety-wrap.sh {begin <file>|check|commit|rollback}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

- New skill `/gsp-polish` scans React/Tailwind/(shadcn) codebases for execution-level craft failures.
- 10-pattern library, each a self-contained `.md` file under `gsp/skills/gsp-polish/patterns/`. Adding a pattern = drop a file.
- Two-tier fix model: `safe-auto` (additive, reversible, tsc-guarded) vs `propose-diff` / `flag-only` (contextual).
- Auto-runs after `gsp-project-build` (opt-out); user-invocable anytime.
- Hard safety net: file backup → apply → `tsc --noEmit` → commit or rollback. Per-file atomic.

## The motivating example

Scrolling text containers with hard-clip edges (no fade mask) are a textbook AI-built tell. `mask-image-on-scrolling-text` catches every `overflow-y-auto` + `max-h-*` without `mask-image` and adds a 12px linear-gradient fade. Purely additive; reversible; tsc-guarded.

## Pattern library

| # | Pattern | Tier | Catches |
|---|---|---|---|
| 1 | `mask-image-on-scrolling-text` | safe-auto | The seed: scrolling text with no fade |
| 2 | `default-recharts-palette` | safe-auto | `#8884d8` / `#82ca9d` in charts |
| 3 | `mobile-text-no-clamp` | safe-auto | `text-6xl` with no responsive ramp |
| 4 | `internal-a-not-link` | safe-auto | `<a href="/x">` instead of next/link |
| 5 | `image-fill-no-relative-parent` | safe-auto | `<Image fill>` with static parent |
| 6 | `transition-all-everywhere` | propose-diff | `transition-all` blanket animation |
| 7 | `lorem-and-placeholder-copy` | flag-only | Lorem ipsum / "John Doe" / "Click here" |
| 8 | `generic-loading-text` | flag-only | `<div>Loading...</div>` instead of skeleton |
| 9 | `missing-empty-state` | flag-only | `.map()` over array with no length-0 guard |
| 10 | `raw-hex-colors-outside-tokens` | flag-only | `bg-[#3b82f6]` bypassing the token system |

## What polish does NOT cover

Stripped during adversarial review to avoid overlapping existing GSP skills:
- focus-visible, tap-target, contrast → `gsp-accessibility-audit`
- font choices → `gsp-typography`
- spacing rhythm → `gsp-project-critique`
- image CLS dimensions → `gsp-project-review`

## Workflow

Built through the full GSP loop (define → research → propose → adversarial → adjust → implement → test). The adversarial pass killed pattern auto-detection at brief-time, identified false-positive risks on shadcn CVA-composed components, and forced the per-file atomic safety net. The user override re-instated auto-fix + pipeline-integration with the safety nets baked in.

## Files

19 files, +1,234 lines:
- `gsp/skills/gsp-polish/SKILL.md` — router (modes, scope resolution)
- `gsp/skills/gsp-polish/methodology/gsp-polisher.md` — agent contract
- `gsp/skills/gsp-polish/patterns/` — INDEX.yml + 10 pattern files
- `gsp/agents/gsp-polisher.md` — agent registration
- `scripts/polish-safety-wrap.sh` — file-backup + tsc check (84 lines, bash + Node)
- `gsp/hooks/hooks.json` — SubagentStop hook for polisher
- `gsp/skills/gsp-project-build/SKILL.md` — auto-invoke at finalize step
- `.gitignore` — polish runtime artifacts
- `CLAUDE.md` — skill/agent count bumps (35→36, 12→13)

## Test plan

- [x] `dev/scripts/audit-tests.sh`: 72 PASS / 3 WARN pre-existing / 0 FAIL
- [x] `scripts/polish-safety-wrap.sh` smoke test: commit, rollback, double-begin error, pre-existing-backup error — all behave correctly
- [x] JSON + bash syntax validation
- [ ] Manual: invoke `/gsp-polish` on a real codebase with at least one of each pattern, verify findings
- [ ] Manual: run `/gsp-project-build` end-to-end and confirm polish auto-runs at finalize
- [ ] Follow-up: integrate with #211 output-modes once that merges (currently writes the full 4-file output set; will collapse to compact mode once policy file exists on main)

## Known soft dependencies

- #211 (output-modes) — polish will honor `chat`/`compact`/`full` once the policy file exists on main. Currently writes the full set always.
- #218 (gsp-brand-coherence agent) — independent; doesn't block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)