### PR TITLE
harness(w4): close 7 enforcement gaps (hooks, audit, CI)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -43,3 +43,16 @@ jobs:
       # Build smoke just verifies buildability, not strict reproducibility.
       - run: npm install --no-audit --no-fund
       - run: npm run build
+
+  shellcheck:
+    name: Shellcheck guard + audit scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Lint scripts/*.sh and dev/scripts/*.sh
+        run: |
+          shopt -s nullglob
+          set -e
+          shellcheck -x scripts/*.sh dev/scripts/*.sh

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -45,14 +45,18 @@ jobs:
       - run: npm run build
 
   shellcheck:
-    name: Shellcheck guard + audit scripts
+    name: Shellcheck guard scripts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
-      - name: Lint scripts/*.sh and dev/scripts/*.sh
+      # Scope: user-facing guard scripts only (scripts/*.sh). These ship with
+      # the npm package and run on every Edit/Write — typos silently disable
+      # enforcement. dev/scripts/*.sh is excluded because it's developer
+      # tooling with accumulated lint debt; cleanup is tracked separately.
+      - name: Lint scripts/*.sh
         run: |
           shopt -s nullglob
           set -e
-          shellcheck -x scripts/*.sh dev/scripts/*.sh
+          shellcheck -x scripts/*.sh

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -45,18 +45,18 @@ jobs:
       - run: npm run build
 
   shellcheck:
-    name: Shellcheck guard scripts
+    name: Shellcheck (guard + dev scripts)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
-      # Scope: user-facing guard scripts only (scripts/*.sh). These ship with
-      # the npm package and run on every Edit/Write — typos silently disable
-      # enforcement. dev/scripts/*.sh is excluded because it's developer
-      # tooling with accumulated lint debt; cleanup is tracked separately.
-      - name: Lint scripts/*.sh
+      # Scope: user-facing guard scripts (scripts/*.sh) plus dev tooling
+      # (dev/scripts/*.sh). Guard scripts ship with the npm package and run on
+      # every Edit/Write — typos silently disable enforcement. Dev scripts
+      # were cleaned up in harness/w4 (gap-9 from the harness audit).
+      - name: Lint scripts/*.sh + dev/scripts/*.sh
         run: |
           shopt -s nullglob
           set -e
-          shellcheck -x scripts/*.sh
+          shellcheck -x scripts/*.sh dev/scripts/*.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ Internal development tools live in `dev/` (versioned in repo, never installed to
 |------|---------|
 | `dev/skills/gspdev-audit/` | Pipeline integrity checker — contracts, installer, runtime compat, versions, templates |
 | `dev/skills/gspdev-runtime-compat/` | Fetch live runtime docs and flag drift against GSP installer |
-| `dev/scripts/audit-tests.sh` | Automated test suite (65 tests across 8 suites) |
+| `dev/scripts/audit-tests.sh` | Automated test suite across 9 suites (versions, contracts, installer, runtime, templates, unit, prompts, tokenbudget, references) |
 | `dev/scripts/token-budget.sh` | Static token budget analyzer — scores skills by estimated API weight |
 | `dev/scripts/token-proxy-start.sh` | Live token proxy — mitmproxy addon for measuring real API usage |
 | `dev/scripts/benchmark.sh` | Token budget benchmarking — capture snapshots, compare against release baseline |

--- a/claude-settings.template.json
+++ b/claude-settings.template.json
@@ -18,6 +18,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_ROOT}/scripts/lint-check.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/dev/scripts/audit-tests.sh
+++ b/dev/scripts/audit-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # GSP Integrity Test Suite
 # Run from repo root: bash dev/scripts/audit-tests.sh [suite]
-# Suites: all, versions, contracts, installer, runtime, templates, unit, prompts, tokenbudget
+# Suites: all, versions, contracts, installer, runtime, templates, unit, prompts, tokenbudget, references
 # Exit code: number of failures
 
 set -uo pipefail
@@ -1347,6 +1347,116 @@ if should_run tokenbudget; then
     fi
   else
     fail "TB1 Token budget script missing" "dev/scripts/token-budget.sh not found"
+  fi
+fi
+
+# ── H: Hooks & Settings ──────────────────────────────
+
+if should_run hooks || should_run contracts || should_run all; then
+  header "Hooks & Settings"
+
+  HOOKS_JSON="gsp/hooks/hooks.json"
+  SETTINGS_TEMPLATE="claude-settings.template.json"
+
+  # H1: JSON validity of hooks.json and settings template
+  for f in "$HOOKS_JSON" "$SETTINGS_TEMPLATE"; do
+    if [[ ! -f "$f" ]]; then
+      fail "H1 Missing JSON file" "$f"
+      continue
+    fi
+    if node -e "JSON.parse(require('fs').readFileSync('$f','utf8'))" 2>/dev/null; then
+      pass "H1 Valid JSON ($f)"
+    else
+      fail "H1 Invalid JSON" "$f does not parse"
+    fi
+  done
+
+  # H2: every hook command's script path resolves
+  # Parses .hooks.*.hooks[].command from both JSON files, extracts the
+  # scripts/X.sh|dev/scripts/X.sh|.claude/hooks/X.js path, asserts it exists.
+  H2_MISSING=0
+  H2_CHECKED=0
+  for f in "$HOOKS_JSON" "$SETTINGS_TEMPLATE"; do
+    [[ -f "$f" ]] || continue
+    # Extract command strings from the .hooks subtree only (not .statusLine etc).
+    COMMANDS=$(node -e "
+      const j = JSON.parse(require('fs').readFileSync('$f','utf8'));
+      const out = new Set();
+      function walk(o) {
+        if (o && typeof o === 'object') {
+          if (typeof o.command === 'string') out.add(o.command);
+          for (const k in o) walk(o[k]);
+        }
+      }
+      walk(j.hooks || {});
+      for (const c of out) console.log(c);
+    " 2>/dev/null)
+    while IFS= read -r cmd; do
+      [[ -z "$cmd" ]] && continue
+      # Strip leading 'bash ' / 'node ' / 'sh ', then take first whitespace-delimited token.
+      # Use awk for portable alternation (BSD sed differs from GNU sed on -E groups).
+      stripped=$(echo "$cmd" | awk '{ if ($1 == "bash" || $1 == "node" || $1 == "sh") { print $2 } else { print $1 } }')
+      # Resolve placeholder ${CLAUDE_PROJECT_ROOT}/ to repo root
+      path="${stripped/\$\{CLAUDE_PROJECT_ROOT\}\//}"
+      # Filter for paths we own (avoid e.g. /bin/sh)
+      [[ "$path" =~ ^(scripts|dev/scripts|\.claude/hooks)/ ]] || continue
+      H2_CHECKED=$((H2_CHECKED + 1))
+      if [[ ! -f "$path" ]]; then
+        fail "H2 Hook script missing" "$f references $path"
+        H2_MISSING=$((H2_MISSING + 1))
+      fi
+    done <<< "$COMMANDS"
+  done
+  if [[ $H2_MISSING -eq 0 && $H2_CHECKED -gt 0 ]]; then
+    pass "H2 All hook command paths resolve ($H2_CHECKED checked)"
+  elif [[ $H2_CHECKED -eq 0 ]]; then
+    warn "H2 No hook commands found to check" "(unexpected — verify parsing)"
+  fi
+
+  # H3: every gsp-* agent has a SubagentStop matcher (or is allowlisted)
+  # Allowlist: agents that legitimately have no on-disk deliverables (none today).
+  H3_ALLOWLIST=""
+  H3_MISSING_AGENTS=()
+  if [[ -f "$HOOKS_JSON" ]]; then
+    MATCHERS=$(node -e "
+      const j = JSON.parse(require('fs').readFileSync('$HOOKS_JSON','utf8'));
+      const ms = new Set();
+      for (const ev in (j.hooks || {})) {
+        for (const entry of j.hooks[ev]) {
+          if (entry.matcher) ms.add(entry.matcher);
+        }
+      }
+      for (const m of ms) console.log(m);
+    " 2>/dev/null)
+    for af in gsp/agents/gsp-*.md; do
+      [[ -f "$af" ]] || continue
+      agent_name=$(basename "$af" .md)
+      [[ " $H3_ALLOWLIST " == *" $agent_name "* ]] && continue
+      if ! grep -qx "$agent_name" <<< "$MATCHERS"; then
+        H3_MISSING_AGENTS+=("$agent_name")
+      fi
+    done
+  fi
+  if [[ ${#H3_MISSING_AGENTS[@]} -eq 0 ]]; then
+    pass "H3 Every gsp-* agent has a SubagentStop matcher"
+  else
+    fail "H3 Agent without SubagentStop matcher" "${H3_MISSING_AGENTS[*]} (add to $HOOKS_JSON or allowlist)"
+  fi
+
+  # H4: no hardcoded .design/ paths in gsp/agents/gsp-*.md
+  # Per CLAUDE.md "Must-never": agents must say "path provided by the skill"
+  # Allowlist: gsp/agents/CLAUDE.md may document the rule + example paths
+  H4_VIOLATORS=()
+  for af in gsp/agents/gsp-*.md; do
+    [[ -f "$af" ]] || continue
+    if grep -qE '\.design/(branding|projects|system|.+/)' "$af"; then
+      H4_VIOLATORS+=("$af")
+    fi
+  done
+  if [[ ${#H4_VIOLATORS[@]} -eq 0 ]]; then
+    pass "H4 No hardcoded .design/ paths in agent files"
+  else
+    fail "H4 Hardcoded .design/ path in agent" "${H4_VIOLATORS[*]} — use 'path provided by the skill that spawned you'"
   fi
 fi
 

--- a/dev/scripts/audit-tests.sh
+++ b/dev/scripts/audit-tests.sh
@@ -7,7 +7,7 @@
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-cd "$ROOT"
+cd "$ROOT" || exit 1
 
 SUITE="${1:-all}"
 PASS=0
@@ -69,8 +69,8 @@ if should_run versions; then
   $V5_OK && pass "V5 Template config versions match ($V_FILE)"
 
   # V6: CLAUDE.md counts match filesystem
-  ACTUAL_SKILLS=$(ls -d gsp/skills/*/SKILL.md 2>/dev/null | wc -l | tr -d ' ')
-  ACTUAL_AGENTS=$(ls gsp/agents/gsp-*.md 2>/dev/null | wc -l | tr -d ' ')
+  ACTUAL_SKILLS=$(find gsp/skills -mindepth 2 -maxdepth 2 -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')
+  ACTUAL_AGENTS=$(find gsp/agents -maxdepth 1 -name 'gsp-*.md' 2>/dev/null | wc -l | tr -d ' ')
   V6_OK=true
   if [[ -f CLAUDE.md ]]; then
     # Check source table counts
@@ -253,11 +253,9 @@ if should_run contracts; then
       fi
     fi
     # Must reference current bundle dirs (templates/)
-    for dir in templates; do
-      if ! grep -q "$dir/" "$UPDATE_SKILL"; then
-        C10_OK=false
-      fi
-    done
+    if ! grep -q "templates/" "$UPDATE_SKILL"; then
+      C10_OK=false
+    fi
     if $C10_OK; then
       pass "C10 Update skill aligned with installer"
     else
@@ -367,12 +365,10 @@ if should_run installer; then
 
   # I5: Bundle directories exist
   BUNDLE_OK=true
-  for dir in gsp/templates; do
-    if [[ ! -d "$dir" ]]; then
-      BUNDLE_OK=false
-      fail "I5 Missing bundle dir" "$dir"
-    fi
-  done
+  if [[ ! -d "gsp/templates" ]]; then
+    BUNDLE_OK=false
+    fail "I5 Missing bundle dir" "gsp/templates"
+  fi
   $BUNDLE_OK && pass "I5 Bundle directories present"
 
   # I6: package.json files field — all entries exist
@@ -530,7 +526,7 @@ if should_run installer; then
       # Resolve: CLAUDE_SKILL_DIR = gsp/skills/<dir>, so ../../ = gsp/
       resolved=$(echo "$ref" | sed "s|\${CLAUDE_SKILL_DIR}/\.\./\.\./|gsp/|" | sed "s|\${CLAUDE_SKILL_DIR}/\.\./|gsp/skills/|" | sed "s|\${CLAUDE_SKILL_DIR}/|gsp/skills/${dir}/|")
       # Strip trailing description after space (e.g. "file.md (index only — ...)")
-      resolved=$(echo "$resolved" | sed 's/ (.*//')
+      resolved="${resolved%% (*}"
       # Skip dynamic refs with {} placeholders
       echo "$resolved" | grep -q '{' && continue
       if [[ ! -e "$resolved" ]]; then
@@ -632,6 +628,7 @@ if should_run installer; then
     [[ -f "$f" ]] || continue
     # Find lines with bare `skills/gsp-` or `references/` paths that aren't preceded by ${CLAUDE_SKILL_DIR}/
     # Skip lines inside <context> blocks (descriptive) and lines with `dev/skills/` (dev-skill refs)
+    # shellcheck disable=SC2016  # literal ${CLAUDE_SKILL_DIR} / `skills/` and literal $ in regex
     while IFS=: read -r ln content; do
       # Skip if line has ${CLAUDE_SKILL_DIR} earlier in the same line
       [[ "$content" == *'${CLAUDE_SKILL_DIR}'* ]] && continue
@@ -661,7 +658,7 @@ if should_run installer; then
   I22_CANDIDATES=()
   PIPELINE_SKILLS=(gsp-brand-research gsp-brand-strategy gsp-brand-identity gsp-brand-guidelines gsp-project-brief gsp-project-research gsp-project-design gsp-project-critique gsp-project-build gsp-project-review)
   for skill in "${PIPELINE_SKILLS[@]}"; do
-    for f in gsp/skills/$skill/SKILL.md gsp/skills/$skill/methodology/*.md; do
+    for f in "gsp/skills/$skill/SKILL.md" "gsp/skills/$skill"/methodology/*.md; do
       [[ -f "$f" ]] || continue
       # Heuristic markers — concrete domain rules typically owned by expertise
       DOMAIN_HITS=$(grep -cE 'Inter/Roboto|off-black not #000|prefers-reduced-motion|tabular-nums|tint shadows|text-wrap: balance' "$f" 2>/dev/null || echo 0)
@@ -754,6 +751,7 @@ if should_run runtime; then
     # OpenCode: /gsp: → /gsp-
     grep -q '/gsp-' bin/install.js || BR_OK=false
     # Codex: /gsp: → $gsp-
+    # shellcheck disable=SC2016  # literal $gsp- pattern to grep
     grep -q '\$gsp-' bin/install.js || BR_OK=false
     if $BR_OK; then
       pass "R5 Command invocation replacements present"
@@ -921,7 +919,7 @@ if should_run templates; then
     done
   done
   if [[ ${#T8_MISSING[@]} -eq 0 ]]; then
-    PRESET_COUNT=$(ls "$STYLE_DIR"/*.yml 2>/dev/null | grep -v INDEX | wc -l | tr -d ' ')
+    PRESET_COUNT=$(find "$STYLE_DIR" -maxdepth 1 -name '*.yml' ! -name 'INDEX*' 2>/dev/null | wc -l | tr -d ' ')
     pass "T8 All $PRESET_COUNT presets have intensity+patterns+constraints+effects"
   else
     fail "T8 Presets missing schema blocks" "${T8_MISSING[*]}"
@@ -1014,6 +1012,7 @@ if should_run references; then
     skill_dir=$(dirname "$src")
 
     # X1: ${CLAUDE_SKILL_DIR}/../<rel> → gsp/skills/<rel>
+    # shellcheck disable=SC2016  # literal ${CLAUDE_SKILL_DIR} in regex
     while IFS= read -r ref; do
       [[ -z "$ref" ]] && continue
       is_placeholder "$ref" && continue
@@ -1158,10 +1157,10 @@ if should_run prompts; then
       HAS_ONE_Q=$(grep -ci 'one decision per question\|one.*question.*at a time' "$skill")
       HAS_ASK=$(grep -ci 'always use.*AskUserQuestion\|AskUserQuestion.*for user' "$skill")
       if [[ "$HAS_ONE_Q" -eq 0 || "$HAS_ASK" -eq 0 ]]; then
-        MISSING=""
-        [[ "$HAS_ONE_Q" -eq 0 ]] && MISSING="one-decision"
-        [[ "$HAS_ASK" -eq 0 ]] && MISSING="${MISSING:+$MISSING+}ask-rule"
-        P4_MISSING+=("$dir:$MISSING")
+        P4_MISSING_TAG=""
+        [[ "$HAS_ONE_Q" -eq 0 ]] && P4_MISSING_TAG="one-decision"
+        [[ "$HAS_ASK" -eq 0 ]] && P4_MISSING_TAG="${P4_MISSING_TAG:+$P4_MISSING_TAG+}ask-rule"
+        P4_MISSING+=("$dir:$P4_MISSING_TAG")
       fi
     fi
   done
@@ -1281,11 +1280,12 @@ if should_run unit; then
 
   # U4: serve-preset.js serves the file and exits on SIGTERM
   TMPJSON=$(mktemp).json
+  # shellcheck disable=SC2016  # literal $schema key in shadcn registry JSON
   echo '{"$schema":"https://ui.shadcn.com/schema/registry-item.json","name":"smoke","type":"registry:theme","cssVars":{"light":{},"dark":{}}}' > "$TMPJSON"
   SERVE_PRESET=gsp/skills/gsp-brand-apply/bin/serve-preset.js
   node "$SERVE_PRESET" "$TMPJSON" > /tmp/gsp-serve-url-$$.txt 2>/dev/null &
   SERVER_PID=$!
-  for i in 1 2 3 4 5; do sleep 0.2; [ -s /tmp/gsp-serve-url-$$.txt ] && break; done
+  for _ in 1 2 3 4 5; do sleep 0.2; [ -s /tmp/gsp-serve-url-$$.txt ] && break; done
   URL=$(head -1 /tmp/gsp-serve-url-$$.txt 2>/dev/null)
   if [[ -n "$URL" && "$URL" == http* ]]; then
     BODY=$(curl -fsS "$URL" 2>/dev/null)

--- a/dev/scripts/audit-tests.sh
+++ b/dev/scripts/audit-tests.sh
@@ -29,7 +29,7 @@ should_run() { [[ "$SUITE" == "all" || "$SUITE" == "$1" ]]; }
 if should_run versions; then
   header "Version Sync"
 
-  V_FILE=$(cat VERSION 2>/dev/null | tr -d '[:space:]')
+  V_FILE=$(tr -d '[:space:]' < VERSION 2>/dev/null)
   V_PKG=$(node -e "process.stdout.write(require('./package.json').version)" 2>/dev/null)
 
   # V1: VERSION and package.json agree

--- a/dev/scripts/benchmark.sh
+++ b/dev/scripts/benchmark.sh
@@ -18,7 +18,7 @@ source "$ROOT/dev/scripts/lib-scoring.sh"
 # ── Helpers ─────────────────────────────────────────
 
 get_version() {
-  cat "$ROOT/VERSION" 2>/dev/null | tr -d '[:space:]'
+  tr -d '[:space:]' < "$ROOT/VERSION" 2>/dev/null
 }
 
 get_branch() {

--- a/dev/scripts/benchmark.sh
+++ b/dev/scripts/benchmark.sh
@@ -6,7 +6,7 @@ set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 LIB_ROOT="$ROOT"
-cd "$ROOT"
+cd "$ROOT" || exit 1
 
 BENCH_DIR="$ROOT/dev/benchmarks"
 SKIP_TESTS=false
@@ -30,15 +30,15 @@ get_commit() {
 }
 
 latest_snapshot() {
-  ls -1 "$BENCH_DIR"/*.json 2>/dev/null | grep -v '\.release\.json$' | sort -V | tail -1
+  find "$BENCH_DIR" -maxdepth 1 -name '*.json' ! -name '*.release.json' 2>/dev/null | sort -V | tail -1
 }
 
 release_snapshot() {
-  ls -1 "$BENCH_DIR"/*.release.json 2>/dev/null | sort -V | tail -1
+  find "$BENCH_DIR" -maxdepth 1 -name '*.release.json' 2>/dev/null | sort -V | tail -1
 }
 
 previous_snapshot() {
-  ls -1 "$BENCH_DIR"/*.json 2>/dev/null | sort -V | tail -2 | head -1
+  find "$BENCH_DIR" -maxdepth 1 -name '*.json' 2>/dev/null | sort -V | tail -2 | head -1
 }
 
 # ── Test Results ────────────────────────────────────
@@ -56,6 +56,8 @@ capture_tests() {
 
   # Strip ANSI codes, parse summary line (macOS-compatible)
   local clean
+  # SC2001 false positive: bash parameter expansion cannot express this regex
+  # shellcheck disable=SC2001
   clean=$(echo "$output" | sed $'s/\033\[[0-9;]*m//g')
   local summary
   summary=$(echo "$clean" | grep "PASS.*WARN.*FAIL" || true)
@@ -72,17 +74,20 @@ capture_tests() {
 
 cmd_capture() {
   local label="${1:-}"
-  local version=$(get_version)
-  local branch=$(get_branch)
-  local commit=$(get_commit)
-  local date=$(date +%Y-%m-%d)
+  local version branch commit date
+  version=$(get_version)
+  branch=$(get_branch)
+  commit=$(get_commit)
+  date=$(date +%Y-%m-%d)
 
   mkdir -p "$BENCH_DIR"
 
   echo -e "${BOLD}Capturing benchmark...${RESET}\n"
 
   # Score all skills once — cache to temp file for pipeline/rate-limit reuse
-  local cache_file=$(mktemp)
+  local cache_file
+  cache_file=$(mktemp)
+  # shellcheck disable=SC2064  # expand $cache_file at trap-set time so cleanup uses correct path
   trap "rm -f '$cache_file'" EXIT
   local skills_json=""
   local total_weight=0
@@ -128,7 +133,8 @@ cmd_capture() {
     local heaviest_score=0
 
     for sname in $pskills; do
-      local cached=$(grep "|${sname}|" "$cache_file" || true)
+      local cached
+      cached=$(grep "|${sname}|" "$cache_file" || true)
       if [[ -n "$cached" ]]; then
         local s="${cached%%|*}"
         pscore=$((pscore + s))
@@ -148,7 +154,8 @@ cmd_capture() {
   # API conversations from cache
   local api_convos=0
   for sname in ${PIPELINE_SKILLS[3]}; do
-    local cached=$(grep "|${sname}|" "$cache_file" || true)
+    local cached
+    cached=$(grep "|${sname}|" "$cache_file" || true)
     if [[ -n "$cached" ]]; then
       IFS='|' read -r _ _ _ _ agents fork _ _ <<< "$cached"
       api_convos=$((api_convos + 1 + agents + fork))
@@ -156,10 +163,11 @@ cmd_capture() {
   done
 
   # Count assets
-  local num_skills=$(find "$ROOT/gsp/skills/gsp-"* -maxdepth 0 -type d 2>/dev/null | wc -l | tr -d ' ')
-  local num_agents=$(find "$ROOT/gsp/agents/gsp-"*.md -type f 2>/dev/null | wc -l | tr -d ' ')
-  local num_presets=$(find "$ROOT/gsp/skills/gsp-style/styles" -name "*.yml" -type f 2>/dev/null | wc -l | tr -d ' ')
-  local num_methods=$(find "$ROOT/gsp/skills" -path "*/methodology/*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+  local num_skills num_agents num_presets num_methods
+  num_skills=$(find "$ROOT/gsp/skills/gsp-"* -maxdepth 0 -type d 2>/dev/null | wc -l | tr -d ' ')
+  num_agents=$(find "$ROOT/gsp/agents/gsp-"*.md -type f 2>/dev/null | wc -l | tr -d ' ')
+  num_presets=$(find "$ROOT/gsp/skills/gsp-style/styles" -name "*.yml" -type f 2>/dev/null | wc -l | tr -d ' ')
+  num_methods=$(find "$ROOT/gsp/skills" -path "*/methodology/*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
 
   # Test results
   if [[ "$SKIP_TESTS" == "true" ]]; then
@@ -230,7 +238,8 @@ ENDJSON
 # ── Release ─────────────────────────────────────────
 
 cmd_release() {
-  local version=$(get_version)
+  local version
+  version=$(get_version)
   local filename="${version}.release.json"
 
   echo -e "${BOLD}Capturing release baseline...${RESET}\n"
@@ -272,7 +281,7 @@ cmd_compare() {
 
   if [[ ! -f "$file_a" ]] || [[ ! -f "$file_b" ]]; then
     echo -e "${RED}Error:${RESET} Need at least 2 snapshots to compare."
-    echo "  Found: $(ls -1 "$BENCH_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ') snapshot(s) in dev/benchmarks/"
+    echo "  Found: $(find "$BENCH_DIR" -maxdepth 1 -name '*.json' 2>/dev/null | wc -l | tr -d ' ') snapshot(s) in dev/benchmarks/"
     echo "  Run: bash dev/scripts/benchmark.sh capture"
     exit 1
   fi
@@ -386,9 +395,9 @@ print()
 # ── Trend ───────────────────────────────────────────
 
 cmd_trend() {
-  local snapshots
-  snapshots=$(ls -1 "$BENCH_DIR"/*.json 2>/dev/null | sort -V)
-  local count=$(echo "$snapshots" | grep -c . 2>/dev/null || echo "0")
+  local snapshots count
+  snapshots=$(find "$BENCH_DIR" -maxdepth 1 -name '*.json' 2>/dev/null | sort -V)
+  count=$(echo "$snapshots" | grep -c . 2>/dev/null || echo "0")
 
   if (( count == 0 )); then
     echo -e "${RED}Error:${RESET} No snapshots found. Run: bash dev/scripts/benchmark.sh capture"
@@ -437,9 +446,9 @@ print()
 # ── List ────────────────────────────────────────────
 
 cmd_list() {
-  local snapshots
-  snapshots=$(ls -1 "$BENCH_DIR"/*.json 2>/dev/null | sort -V)
-  local count=$(echo "$snapshots" | grep -c . 2>/dev/null || echo "0")
+  local snapshots count
+  snapshots=$(find "$BENCH_DIR" -maxdepth 1 -name '*.json' 2>/dev/null | sort -V)
+  count=$(echo "$snapshots" | grep -c . 2>/dev/null || echo "0")
 
   if (( count == 0 )); then
     echo "  No snapshots. Run: bash dev/scripts/benchmark.sh capture"

--- a/dev/scripts/lib-scoring.sh
+++ b/dev/scripts/lib-scoring.sh
@@ -15,8 +15,12 @@ FORK_WEIGHT=300
 GREEN='\033[32m'
 YELLOW='\033[33m'
 RED='\033[31m'
+# Used by sourcing scripts (benchmark.sh, token-budget.sh)
+# shellcheck disable=SC2034
 BOLD='\033[1m'
+# shellcheck disable=SC2034
 DIM='\033[2m'
+# shellcheck disable=SC2034
 RESET='\033[0m'
 
 # ── Scoring Helpers ─────────────────────────────────
@@ -59,7 +63,8 @@ _load_agent_names() {
 
 score_skill() {
   local skill_dir="$1"
-  local skill_name=$(basename "$skill_dir")
+  local skill_name
+  skill_name=$(basename "$skill_dir")
   local skill_md="$skill_dir/SKILL.md"
 
   # 1. Body lines
@@ -71,7 +76,8 @@ score_skill() {
   # 2. Execution context lines from @ references
   local exec_context_lines=0
   if [[ -f "$skill_md" ]]; then
-    local exec_block=$(sed -n '/<execution_context>/,/<\/execution_context>/p' "$skill_md")
+    local exec_block
+    exec_block=$(sed -n '/<execution_context>/,/<\/execution_context>/p' "$skill_md")
     if [[ -n "$exec_block" ]]; then
       while IFS= read -r ref_line; do
         if [[ "$ref_line" =~ @\$\{CLAUDE_SKILL_DIR\}(.*) ]]; then
@@ -81,7 +87,8 @@ score_skill() {
           ref_path="${ref_path%% }"
           local resolved_ref="$skill_dir$ref_path"
           if [[ -f "$resolved_ref" ]]; then
-            local ref_lines=$(wc -l < "$resolved_ref" | tr -d ' ')
+            local ref_lines
+            ref_lines=$(wc -l < "$resolved_ref" | tr -d ' ')
             exec_context_lines=$((exec_context_lines + ref_lines))
           fi
         fi
@@ -104,7 +111,15 @@ score_skill() {
 
     local unique_agents=()
     for agent in "${found_agents[@]:-}"; do
-      if [[ ! " ${unique_agents[@]:-} " =~ " ${agent} " ]]; then
+      local already_seen=false
+      local seen
+      for seen in "${unique_agents[@]:-}"; do
+        if [[ "$seen" == "$agent" ]]; then
+          already_seen=true
+          break
+        fi
+      done
+      if [[ "$already_seen" == "false" ]]; then
         unique_agents+=("$agent")
       fi
     done
@@ -143,6 +158,8 @@ score_skill() {
 
 # ── Pipeline Definitions ────────────────────────────
 
+# Consumed by sourcing scripts (benchmark.sh, token-budget.sh)
+# shellcheck disable=SC2034
 PIPELINE_NAMES=(
   "brand_diamond"
   "project_diamond"
@@ -150,6 +167,7 @@ PIPELINE_NAMES=(
   "full_e2e"
 )
 
+# shellcheck disable=SC2034
 PIPELINE_DISPLAY=(
   "brand diamond"
   "project diamond"
@@ -157,6 +175,7 @@ PIPELINE_DISPLAY=(
   "full e2e"
 )
 
+# shellcheck disable=SC2034
 PIPELINE_SKILLS=(
   "gsp-start gsp-brand-brief gsp-brand-research gsp-brand-strategy gsp-brand-identity gsp-brand-guidelines"
   "gsp-project-brief gsp-project-research gsp-project-design gsp-project-critique gsp-project-build gsp-project-review"

--- a/dev/scripts/token-budget.sh
+++ b/dev/scripts/token-budget.sh
@@ -7,7 +7,7 @@ set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 LIB_ROOT="$ROOT"
-cd "$ROOT"
+cd "$ROOT" || exit 1
 
 # ── Shared scoring lib ──────────────────────────────
 
@@ -63,7 +63,8 @@ main() {
       details="$details + $methodology_lines methodology"
     fi
 
-    local icon=$(risk_icon "$score")
+    local icon
+    icon=$(risk_icon "$score")
     printf "  %s %-35s %4d  (%s)\n" "$icon" "$skill_name" "$score" "$details"
   done
 
@@ -98,7 +99,8 @@ main() {
       fi
     done
 
-    local color=$(risk_color $((path_count > 0 ? path_score / path_count : 0)))
+    local color
+    color=$(risk_color $((path_count > 0 ? path_score / path_count : 0)))
     printf "  ${color}%-25s${RESET} %5d  (%d skills, heaviest: %s at %d)\n" \
       "$path_name" "$path_score" "$path_count" "$heaviest_skill" "$heaviest_score"
   done

--- a/gsp/hooks/hooks.json
+++ b/gsp/hooks/hooks.json
@@ -139,6 +139,15 @@
             "prompt": "The gsp-polisher agent just finished. Verify: (1) polish/findings.md was written, (2) polish/INDEX.md was written. (3) If any safe-auto fixes were applied, verify scripts/polish-safety-wrap.sh was used (look for absence of orphaned .polish-stash-ref files in the project root). (4) Confirm any rolled-back findings appear in polish/findings.md with a rollback-reason. Report any missing deliverables or orphaned stash refs."
           }
         ]
+      },
+      {
+        "matcher": "gsp-brand-coherence",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "The gsp-brand-coherence agent just finished. Verify: (1) the coherence verdict was written to patterns/INDEX.md or returned in stdout (the agent doesn't always emit a file — its primary output is a Pass/Fail/Conditional verdict on archetype tension and intensity dial alignment). (2) If coherence verdict was Fail or Conditional Pass, surface this to the user before continuing the pipeline. Report any missing verdict."
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

Batches 7 xs-effort harness hardening items identified by a structured audit of the Claude Code enforcement layer (`scripts/`, `claude-settings.template.json`, `gsp/hooks/`, `dev/scripts/audit-tests.sh`, `.github/workflows/`). Each was a real gap with either a silent-failure risk or a documented rule that wasn't mechanically enforced.

## Gaps closed

### Hooks wired

| Gap | Before | After |
|---|---|---|
| **gap-2** | `scripts/lint-check.sh` existed but `claude-settings.template.json` had 0 references — the w3 "unmute lint hook" landed the script without registering it | PostToolUse `Edit\|Write` hook runs lint after every file edit |
| **gap-1** | `gsp/hooks/hooks.json` had verifiers for 10 of 11 agents; missing `gsp-brand-coherence` | Coherence matcher added with verdict-verification prompt |

### audit-tests.sh — new **H** suite (Hooks & Settings)

| Test | Catches |
|---|---|
| **H1** | Trailing comma silently disables all hooks (JSON validity for `hooks.json` + settings template) |
| **H2** | Rename `scripts/foo.sh` → silently breaks every install (parses `.hooks` command paths, asserts existence) |
| **H3** | New agent ships without a verifier (asserts every `gsp-*` agent has a SubagentStop matcher) |
| **H4** | Agent regresses with hardcoded `.design/` path (CLAUDE.md "must-never" enforcement) |

### CI hardening

| Gap | Fix |
|---|---|
| **gap-9** | Adds shellcheck step to `audit.yml` covering `scripts/*.sh` + `dev/scripts/*.sh` |
| **gap-5** | Doc drift — `audit-tests.sh` header now lists `references` suite; workflow job name dropped stale "(65 tests)" count; CLAUDE.md "Running tests" reflects 9 suites |

## Side-effects

- **Closes #218** — verified false alarm. `gsp-brand-coherence.md` does exist on main; the original brand-pipeline verification subagent saw stale state. H3 prevents this false-alarm category going forward.

## Test plan

- [x] `bash dev/scripts/audit-tests.sh` — **77 PASS / 3 WARN pre-existing / 0 FAIL** (was 72 PASS pre-H suite)
- [x] H suite verified end-to-end (5 tests, all green)
- [x] `bash -n` syntax-check on `audit-tests.sh` (BSD-sed quirk fixed: switched to awk for portable alternation)
- [ ] CI: shellcheck job will surface any pre-existing issues in `scripts/*.sh` — landing the job for the first time may turn up violations to fix in a follow-up

## Gaps deferred (in original audit, not in this PR)

| Gap | Why deferred |
|---|---|
| **gap-6** | "No `.design/` writes from skills" rule — needs s-effort static grep of all skill bodies + methodologies. Separate PR. |
| **gap-8** | ESLint scope to `bin/**` + `scripts/**/*.js` — needs config glob extension + may surface existing violations. Separate PR. |
| **gap-10** | CLAUDE.md token-rot check (verify referenced filenames exist) — s-effort. Separate PR. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)