### PR TITLE
fix: brand pipeline audit trail + entry-point prerequisites

### DIFF
--- a/gsp/skills/gsp-accessibility/SKILL.md
+++ b/gsp/skills/gsp-accessibility/SKILL.md
@@ -46,7 +46,7 @@ Read `$ARGUMENTS` to determine the mode:
 |-------|------|--------|
 | `--check #FG #BG` | Quick contrast check | Display only |
 | `--tokens` | Token-only: contrast pairs, sizing, spacing | `critique/accessibility-token-audit.md` |
-| `--validate <yml-path>` | Pre-emit gate: validate a brand `.yml` for WCAG compliance | Exit 0 (pass) / exit 1 (fail) — failures to stdout, no file writes |
+| `--validate <yml-path>` | Pre-emit gate: validate a brand `.yml` for WCAG compliance | Exit 0 (pass) / exit 1 (fail) — verdict to stdout, audit trail appended to `<yml-dir>/wcag-validate.log` |
 | (no args) | Mode picker | Prompt user |
 
 Additional flag: `--level AAA` overrides conformance level (default: AA).
@@ -214,7 +214,7 @@ Display result and use `AskUserQuestion`:
 
 Pre-emit gate for `gsp-brand-guidelines` (and any caller that needs a yes/no contrast verdict on a brand `.yml` without project context).
 
-**Differs from `--tokens`:** no project resolution, no file writes, returns exit code instead of writing a chunk. Use when you need a hard PASS/FAIL gate before downstream emission.
+**Differs from `--tokens`:** no project resolution, no chunk file. Verdict is carried by exit code + stdout; an append-only audit log is written next to the validated `.yml` so post-hoc reviewers can confirm the gate ran. Use when you need a hard PASS/FAIL gate before downstream emission.
 
 ### Inputs
 
@@ -253,7 +253,24 @@ Skip the `--tokens` extras (touch targets, typography minimums) — those are no
   Fix via: /gsp-brand-refine "{token-name} contrast"
 ```
 
-**No file writes.** This mode is a callable gate — output goes to stdout, exit code carries the verdict. Stop here; no AskUserQuestion routing.
+### Audit log (both verdicts)
+
+After printing the stdout verdict, append an entry to `<dirname of yml-path>/wcag-validate.log` so the gate is auditable post-hoc (compliance claims need a trail). Create the file if it doesn't exist.
+
+Entry format:
+
+```
+─── {ISO 8601 timestamp} ─── WCAG 2.2 {level} ─── {PASS|FAIL} ───
+yml: {yml-name}
+pairs checked: {N}
+
+| Pair | FG | BG | Ratio | Required | Result |
+|------|----|----|-------|----------|--------|
+| {semantic name} | {fg hex} | {bg hex} | {ratio}:1 | {threshold}:1 | PASS/FAIL |
+...
+```
+
+One block per invocation; newest at the bottom. The log is the only file write in this mode — no chunks, no STATE.md updates. Stop here; no AskUserQuestion routing.
 
 ## Step 5: Update STATE.md
 

--- a/gsp/skills/gsp-brand-guidelines/SKILL.md
+++ b/gsp/skills/gsp-brand-guidelines/SKILL.md
@@ -14,6 +14,8 @@ allowed-tools:
 Phase 4 of the GSP branding diamond. Transforms the brand identity into operational artifacts that designer and builder agents consume — the `.yml` preset (source of truth), STYLE.md (agent contract), component token mapping, and `guidelines.html` (what the user sees).
 
 Identity made the creative decisions. This phase makes them work in code.
+
+**Prerequisites:** `/gsp-start` → `/gsp-brand-research` → `/gsp-brand-strategy` → `/gsp-brand-identity` must complete first. Guidelines reads `identity/INDEX.md` and strategy chunks; if Phase 3 isn't complete, exits with a next-step prompt instead of running.
 </context>
 
 <objective>
@@ -224,6 +226,8 @@ Invoke `/gsp-accessibility --validate {BRAND_PATH}/patterns/{brand-name}.yml` (u
 
 - **Pass (exit 0):** continue to Step 4.75
 - **Fail (exit 1):** STOP. The skill prints failing token pairs + the recommended fix path. Surface the failures to the user with: `Theme emission blocked — {N} contrast failure(s). Run /gsp-brand-refine to fix the failing pairs, then re-run /gsp-brand-guidelines.` Do NOT emit theme.json. The pipeline is incomplete until validation passes
+
+The verdict (pass or fail) is appended to `{BRAND_PATH}/patterns/wcag-validate.log` — the audit trail proving the gate ran. Do not delete or rewrite this file; it accumulates across reruns.
 
 ## Step 4.75: Emit shadcn theme registry artifact
 

--- a/gsp/skills/gsp-brand-identity/SKILL.md
+++ b/gsp/skills/gsp-brand-identity/SKILL.md
@@ -13,6 +13,8 @@ allowed-tools:
 ---
 <context>
 Phase 3 of the GSP branding diamond. Creates the visual identity — logo system, color, typography, imagery — grounded in the strategy and voice defined in Phase 2.
+
+**Prerequisites:** `/gsp-start` → `/gsp-brand-research` → `/gsp-brand-strategy` must complete first. Identity reads strategy chunks and BRIEF.md as required input; missing scaffolding or an incomplete Phase 2 exits with a next-step prompt.
 </context>
 
 <objective>

--- a/gsp/skills/gsp-brand-research/SKILL.md
+++ b/gsp/skills/gsp-brand-research/SKILL.md
@@ -13,6 +13,8 @@ allowed-tools:
 ---
 <context>
 Phase 1 of the GSP branding diamond. Researches market landscape, competitive positioning, and design trends to inform brand strategy. Personas are already defined in BRIEF.md — this phase validates and enriches the market context around them.
+
+**Prerequisites:** `/gsp-start` must have run first to scaffold `.design/branding/{brand}/BRIEF.md` and `config.json`. Invoking this skill cold (no brand directory) exits with a one-line "run /gsp-start first" prompt — it does not bootstrap.
 </context>
 
 <objective>

--- a/gsp/skills/gsp-brand-strategy/SKILL.md
+++ b/gsp/skills/gsp-brand-strategy/SKILL.md
@@ -13,6 +13,8 @@ allowed-tools:
 ---
 <context>
 Phase 2 of the GSP branding diamond. Interactive creative session — present research insights, collaborate on archetype and positioning, then produce full strategy including voice and messaging. This phase replaces the previous separate strategy + verbal phases.
+
+**Prerequisites:** `/gsp-start` scaffolds the brand directory, then `/gsp-brand-research` (Phase 1) produces the discover chunks this phase reads. Strategy will run on BRIEF.md alone if discover chunks are absent, but invoking it before `/gsp-start` exits with "run /gsp-start first" — it does not bootstrap.
 </context>
 
 <objective>


### PR DESCRIPTION
## Summary
- Closes #220 — `/gsp-accessibility --validate` now appends a timestamped pass/fail block (yml name, pair table, verdict) to `<yml-dir>/wcag-validate.log`, giving the brand-guidelines WCAG gate at Step 4.7 a post-hoc auditable trail.
- Closes #219 — each brand-phase skill (research, strategy, identity, guidelines) opens with a `**Prerequisites:**` line spelling out the required upstream chain (`/gsp-start` → … → current phase). Documentation-only fix; runtime behavior unchanged.

## Notes
- Validate mode's stdout output + exit code contract unchanged. Log is the only new file write, kept next to the validated `.yml`.
- `gsp-brand-guidelines/SKILL.md` Step 4.7 call site updated to point reviewers at the log and note it accumulates across reruns.
- Audit script (`dev/scripts/audit-tests.sh`): 73 PASS / 2 WARN / 0 FAIL — same warning set as before the edits.

## Test plan
- [ ] Run `/gsp-brand-guidelines` end-to-end on a brand with a failing pair → confirm `wcag-validate.log` records the fail block, then a pass block after `/gsp-brand-refine`.
- [ ] Invoke `/gsp-brand-research` cold (no brand dir) → confirm prereq prompt still surfaces cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)