### PR TITLE
perf: slim gsp-doctor body 400L → 149L

### DIFF
--- a/gsp/skills/gsp-doctor/SKILL.md
+++ b/gsp/skills/gsp-doctor/SKILL.md
@@ -51,273 +51,35 @@ For each instance, read:
 
 ## Step 3: Run checks per instance
 
-### Per-Brand Checks (4-phase)
+Load `${CLAUDE_SKILL_DIR}/checks.md` — the full check catalog with pass/warn/fail criteria. Read it once at this step; do not load it before Step 2 because the applicable check sets depend on what was scanned.
 
-**Check B1: Brand Structure**
-Required: config.json, STATE.md, BRIEF.md
-Required dirs: discover/, strategy/, identity/, patterns/
-Missing → FAIL
+Run only the sets applicable to the detected state:
 
-**Check B2: Brand Phase Ordering**
-No phase complete if earlier phase is pending (discover < strategy < identity < patterns).
-Exception: strategy can proceed without discover.
+| Detected | Run |
+|----------|-----|
+| Each brand instance | B1, B2, B3, B4 |
+| Each project instance | P1–P10 |
+| Always (installation) | I1, I2, I3, I4, I5 |
+| Project has `implementation_target: shadcn` and `.design/system/STACK.md` exists | S1–S5 |
+| Multiple projects reference the same brand | X1 |
 
-**Check B3: Brand Completeness**
-If all 4 phases complete, check:
-- `identity/INDEX.md` exists (chunk format)
-- `identity/palettes.json` exists (WARN if missing)
-- `patterns/INDEX.md` exists (chunk format)
-- `patterns/*.yml` preset exists (WARN if missing)
-- If monolith exists without INDEX.md → WARN: "Legacy monolith format"
+For each check, record the verdict (PASS/WARN/FAIL/INFO) plus a short instance-tagged message for issues.
 
-**Check B4: Legacy Monolith Detection**
-For each brand phase directory (discover, strategy, identity, patterns):
-- If monolith exists but no INDEX.md → WARN: "Monolith files are no longer supported in GSP v0.6.0+. Re-run `/gsp-brand-{phase}` to generate chunk output."
-
-### Per-Project Checks (6-phase)
-
-**Check P1: Project Structure**
-
-**What it catches:** Missing core files, incomplete setup.
-
-Required: config.json, STATE.md, BRIEF.md, brand.ref
-Required dirs: brief/, research/, design/, critique/, build/, review/
-
-Check each exists:
-- All present → PASS
-- Core files missing → FAIL: list which are missing, suggest `/gsp-start`
-
-**Monorepo app_path check:**
-- If `repo_type` is `monorepo` (in config.json) and `app_path` is empty → WARN: "Project has no `app_path` set. Run `/gsp-project-brief` to assign a target app."
-
-**Design system check:**
-- If `.design/system/` directory exists, verify at least `STACK.md` is present → PASS
-- If `.design/system/` is missing and codebase is not greenfield → WARN: "Design system scan missing. Run `/gsp-design-system` to scan."
-- If old project-scoped `codebase/INVENTORY.md` exists → WARN: "Legacy INVENTORY.md found. Run `/gsp-design-system` to migrate to workspace-level design system docs."
-
-Legacy detection: if system/, screens/, specs/, plan/ dirs exist → WARN: "Legacy structure detected — project uses old phase layout"
-
-**Check P2: Brand Reference**
-Read brand.ref → check brand exists in `.design/branding/{name}/`
-Check brand system is complete (system phase = complete)
-WARN if brand referenced but system not complete
-
-**Check P3: Brand Drift**
-Read `identity_hash` from brand.ref
-If brand identity/IDENTITY.md exists, compute current hash (first 8 chars of md5)
-If hashes differ → WARN: "Brand identity has changed since project consumed it. Consider re-running `/gsp-project-brief`."
-If identity_hash is "pending" → INFO: "Brand identity wasn't complete when project was created."
-
-**Check P4: Phase Ordering**
-
-**What it catches:** Phases completed out of order, skipped prerequisites.
-
-Read STATE.md phase table. Check ordering rules:
-brief < research < design < critique < build < review
-
-1. No phase should be `complete` if an earlier required phase is still `pending` (not `skipped` or `complete`)
-2. Valid skip scenarios (not violations):
-   - design skipped when `design_scope` is `tokens`
-   - research can proceed without brief
-3. build complete but critique pending → WARN: "Build completed without critique. Run `/gsp-project-critique` to audit."
-4. Any other out-of-order completion → FAIL with specifics
-
-All phases in order (or validly skipped) → PASS
-
-**Check P5: Stale Outputs**
-
-**What it catches:** Output content that doesn't match current config expectations.
-
-Only check phases that are `complete`. All paths relative to the project instance directory.
-
-**When `system_strategy` is `extend`:**
-- Check if brand's `patterns/` output contains "Component Audit" or "KEEP" or "RESTYLE" or "REFACTOR" or "REPLACE"
-- If none found → WARN: "Strategy is `extend` but system output lacks component audit table. Re-run `/gsp-brand-guidelines`."
-
-**When `implementation_target` is `shadcn`:**
-- If brief phase is complete, check brief/ output for "shadcn" or "npx shadcn"
-- If not found → WARN: "Target is `shadcn` but brief doesn't reference shadcn components."
-
-**When `implementation_target` is `rn-reusables`:**
-- If brief phase is complete, check brief/ output for "reusables" or "NativeWind"
-- If not found → WARN: "Target is `rn-reusables` but brief doesn't reference RN Reusables."
-
-**When `design_scope` is `tokens`:**
-- design phase should be `skipped`, not `complete`
-- If `complete` → WARN: "Scope is `tokens` but design phase ran as full. Outputs may be unnecessary."
-
-No stale outputs detected → PASS
-
-**Check P6: Config Drift**
-
-**What it catches:** Config says one thing, outputs reflect another.
-
-**Check `system_strategy` alignment:**
-- Config says `extend` but brand system output contains "## Components" with 30+ component specs (no audit table) → WARN: "Config says `extend` but system looks like a full `generate`. Config may be out of sync."
-- Config says `generate` but brand system output contains "Component Audit" → WARN: "Config says `generate` but system contains extend-style audit."
-
-**Check `codebase_type` alignment:**
-- Config says `existing` or `boilerplate` but no `.design/system/STACK.md` → WARN (already caught by P1, don't double-count)
-- Config says `greenfield` but `.design/system/STACK.md` exists → INFO: "Config says `greenfield` but design system docs exist. Not an issue, but config may be stale."
-
-**Check `design_scope` alignment:**
-- Config says `tokens` but design/ has full screen designs → WARN: "Scope is `tokens` but design/ has full screen designs."
-- Config says `partial` — check BRIEF.md for "Target screens" section. If missing → WARN: "Scope is `partial` but BRIEF.md doesn't specify target screens."
-
-No drift detected → PASS
-
-**Check P7: Missing Chunks**
-
-**What it catches:** Chunk directories missing, INDEX.md references broken.
-
-For each completed project phase (brief, research, design, critique, build, review):
-- Check for `{phase}/INDEX.md` — if missing → WARN: "Phase {phase} is complete but has no INDEX.md. Re-run `/gsp-{command}` to generate chunks."
-
-**If exports/INDEX.md exists, check for broken references:**
-- Read INDEX.md, extract all file paths from markdown links
-- Check each referenced file exists
-
-Broken INDEX.md references → WARN: list broken paths
-INDEX.md has unpopulated BEGIN/END sections for completed phases → WARN: "INDEX.md has empty sections for completed phases."
-
-No chunks expected yet (no phases complete) → PASS
-All chunks present and references valid → PASS
-
-Legacy path detection: if `screens/` exists instead of `design/` → WARN
-
-**Check P8: Broken References**
-
-**What it catches:** Cross-file references that point to non-existent content.
-
-**design/ → brand system:**
-If both exist, extract component names referenced in design chunks (look for patterns like "Uses: {ComponentName}" or component references). Check each exists in the brand's system output.
-
-Components referenced in designs but not in system → WARN: "Design references components not defined in brand system: {list}. Re-run `/gsp-brand-guidelines` to add them, or update designs."
-
-**critique/ → design/:**
-If both exist, extract screen references from critique chunks. Check each referenced screen exists in design/.
-
-Screens referenced in critique but not in designs → WARN: "Critique references screens not in design/: {list}."
-
-No broken references → PASS
-
-**Check P9: Review Status**
-
-**What it catches:** Stuck review loops, unaddressed critical issues.
-
-Read STATE.md review loop table:
-- Count review iterations
-- If > 3 iterations → WARN: "Review has looped {N} times. Consider addressing root causes or accepting current state."
-
-If critique phase status is `needs-revision`:
-- Check if any later phase (build, review) is `complete` → FAIL: "Build/Review completed while critique still needs revision."
-
-If critique/ contains chunks with "Critical" severity items:
-- If critique phase status is `complete` (not `needs-revision`) → INFO: "Critique has critical items but phase is marked complete. Verify issues were addressed."
-
-No review issues → PASS
-
-**Check P10: Upgrade Detection**
-
-**What it catches:** Project created with older GSP version, missing features now available.
-
-**Config version check:**
-- If `version` field exists in config.json, note it
-- If version is older than current (0.5.0) → WARN: "Config version is {version}, current GSP is 0.5.0. Some features may not be active."
-- If no `version` field → INFO: "Config has no version stamp. Project may predate versioned configs."
-
-**Chunk format check:**
-- If any phase is complete but has no INDEX.md and no chunk files → WARN: "Project may predate chunked exports. Consider re-running phases to get chunked output."
-
-**palettes.json check:**
-- If brand's identity phase is complete, check for `identity/palettes.json`
-- If missing → INFO: "No tints.dev palettes found. Re-run `/gsp-brand-identity` to generate OKLCH color palettes."
-
-No upgrade concerns → PASS
-
-### Installation Health Checks
-
-**Check I1: Skills have `user-invocable: true`**
-Glob for all SKILL.md files in the skills directory (`{runtime-dir}/skills/*/SKILL.md` — e.g. `.claude/skills/` for Claude Code, `.opencode/skills/` for OpenCode, `.gemini/skills/` for Gemini). For each skill (except the entry point `get-shit-pretty`), check frontmatter for `user-invocable: true`.
-- All present → PASS
-- Missing → WARN: "Skills missing `user-invocable: true`: {list}. They won't appear in the slash-command menu. Re-run the installer or add the field manually."
-
-**Check I2: Skill directories are complete (not just SKILL.md)**
-For each gsp-* skill directory, check if `SKILL.md` references sibling files via `${CLAUDE_SKILL_DIR}/` paths (e.g. `styles/INDEX.yml`). If it does, verify those files/dirs exist in the installed skill directory.
-- All referenced siblings present → PASS
-- Missing siblings → FAIL: "Skill {name} references {path} but it's missing. Re-run the installer: `pnpm dlx get-shit-pretty` (or `bunx get-shit-pretty`)"
-
-**Check I3: Bundle directories accessible**
-Check that the runtime bundle directories exist (`{runtime-dir}/templates/`, `{runtime-dir}/references/`). Skills reference these via `${CLAUDE_SKILL_DIR}/../../`.
-- All present → PASS
-- Missing → FAIL: "Bundle directory {dir} missing. Re-run the installer: `pnpm dlx get-shit-pretty` (or `bunx get-shit-pretty`)"
-
-**Check I4: VERSION file present**
-Check `{runtime-dir}/VERSION` exists and contains a valid semver string.
-- Present and valid → PASS (show version)
-- Missing → WARN: "VERSION file missing. Re-run the installer."
-- Mismatched with source → INFO: "Installed version {installed} differs from source {source}."
-
-**Check I5: No duplicate skills (stale global install)**
-Check if `~/.claude/skills/` contains `gsp-*` directories when running from a local install. These cause duplicates between global and local.
-- Run: `ls ~/.claude/skills/ | grep '^gsp-'`
-- No matches → PASS
-- Matches found → FAIL: "Found {N} stale GSP skills in ~/.claude/skills/. Fix: run `pnpm dlx get-shit-pretty --claude --local` (or `bunx get-shit-pretty --claude --local`) to reinstall (the installer cleans stale globals automatically), or manually remove: `rm -rf ~/.claude/skills/gsp-*`"
-
-### Stack Compliance Checks (shadcn targets)
-
-Only run these checks when `.design/system/STACK.md` exists and at least one project has `implementation_target: shadcn`.
-
-> **Monorepo note:** For monorepos, each project's S-checks run in its declared `app_path`. Read `config.json` → `preferences.app_path` before running commands. If `app_path` is empty, run in repo root.
-
-**Check S1: Alias drift**
-
-Read `config.json` → `preferences.app_path`. Set `APP_PATH` (default `.` if empty).
-
-Run `cd {APP_PATH} && npx shadcn@latest info --json` and extract `aliases.components`. Compare to `## Key Paths → Components` in STACK.md.
-
-If mismatch → FAIL: "shadcn alias drift — STACK.md declares `{declared}` but live config has `{live}`. Imports will break. Fix by updating `components.json` or `STACK.md`."
-
-**Check S2: Tailwind version drift**
-
-Run `cd {APP_PATH} && node -e "console.log(require('tailwindcss/package.json').version)"`. Compare major version to `## Tech Stack → Styling` in STACK.md.
-
-If major version differs → FAIL: "Tailwind version drift — STACK.md declares `{declared}` but `{live}` is installed. Run `/gsp-scaffold` to realign or update STACK.md."
-
-**Check S3: Icon library drift**
-
-Read `components.json` → `iconLibrary`. Compare to icon library recorded in STACK.md (if present).
-
-If mismatch → WARN: "Icon library drift — STACK.md declares `{declared}` but `components.json` says `{live}`. Agents may import from the wrong package."
-
-**Check S4: Token presence in globals.css**
-
-Find the global CSS file (from `cd {APP_PATH} && npx shadcn@latest info --json` → `tailwindCssFile`, or glob for `globals.css` inside `APP_PATH`). Check it contains `--background`, `--foreground`, `--primary` CSS custom properties.
-
-If missing → WARN: "CSS custom properties not found in `{file}`. Token integration may be incomplete. Run `/gsp-project-build` foundations phase to regenerate."
-
-**Check S5: Tailwind v4 source scoping (if Tailwind v4)**
-
-If Tailwind v4 detected, check `globals.css` for `@import "tailwindcss"`. If present without `source(...)` modifier, and the repo contains non-source directories with Tailwind class names (like `.design/`) → WARN: "Tailwind v4 source not scoped. Add `source(\"../\")` to avoid scanning `.design/` spec files."
-
-All S checks pass → single PASS line: "S1-S5. Stack compliance .......... PASS"
-
-
-
-**Check X1: Multiple projects, same brand**
-If multiple projects reference the same brand, and brand has changed since any project consumed it → WARN with list of affected projects.
+**De-duplication:** if the same underlying issue is caught by multiple checks, only report it once — keep it in the most specific check.
 
 ## Step 4: Calculate health score
 
 Score per instance (100 points each):
 - Each FAIL: -15 points
 - Each WARN: -5 points
-- Each INFO: -0 points
+- Each INFO: 0 points
 - Minimum: 0
 
 Overall score: average of all instance scores.
 
 ## Step 5: Display diagnostic
+
+Render to terminal only (no file writes). One section per instance, then installation, stack, cross-instance, then issues, then summary.
 
 ```
 🩺 GSP Doctor — Project Health Check
@@ -331,64 +93,51 @@ Overall Health: {SCORE}/100 {emoji}
 
 ─── Brand: {name} ─────────────────────
   Phases: {N}/4 complete
-  ✅ B1. Structure .............. PASS
-  ✅ B2. Phase Ordering ......... PASS
-  ⚠️  B3. Completeness .......... WARN
+  {check ID}. {short label} ............ {PASS|WARN|FAIL}
+  ...
 
 ─── Project: {name} (brand: {brand}) ──
   Phases: {N}/6 complete
-  ✅ P1. Structure .............. PASS
-  ✅ P2. Brand Reference ........ PASS
-  ⚠️  P3. Brand Drift ........... WARN
-  ✅ P4. Phase Ordering ......... PASS
-  ✅ P5. Stale Outputs .......... PASS
-  ✅ P6. Config Drift ........... PASS
-  ✅ P7. Missing Chunks ......... PASS
-  ✅ P8. Broken References ...... PASS
-  ✅ P9. Review Status .......... PASS
-  ✅ P10. Upgrade Detection ..... PASS
+  P1. Structure .................. {verdict}
+  ... (P2–P10)
 
 ─── Installation Health ───────────────
-  ✅ I1. Skills invocable ........ PASS
-  ✅ I2. Skill completeness ...... PASS
-  ✅ I3. Bundle directories ...... PASS
-  ✅ I4. VERSION file ............ PASS
-  ✅ I5. No duplicate skills ..... PASS
+  I1. Skills invocable ........... {verdict}
+  ... (I2–I5)
 
-  ─── Stack Compliance (shadcn) ────────
-  ✅ S1. Alias ....................... PASS
-  ✅ S2. Tailwind version ........... PASS
-  ✅ S3. Icon library ............... PASS
-  ✅ S4. CSS custom properties ....... PASS
-  ✅ S5. Source scoping .............. PASS
+─── Stack Compliance (shadcn) ─────────   (only if S checks ran)
+  S1–S5. Stack compliance ........ {aggregate verdict}
 
-  ─── Cross-Instance ────────────────────
-  ✅ X1. Brand Consistency ...... PASS
+─── Cross-Instance ────────────────────
+  X1. Brand Consistency .......... {verdict}
 
 ─── Issues Found ──────────────────────
 
 FAIL:
-  • [acme-website/P1] Missing brand.ref
-    → Fix: Re-run /gsp-start to set up project with brand reference
+  • [{instance}/{check}] {message}
+    → Fix: {suggested command}
 
 WARN:
-  • [acme-corp/B3] No palettes.json found
-    → Fix: Re-run /gsp-brand-identity to generate OKLCH palettes
+  • [{instance}/{check}] {message}
+    → Fix: {suggested command}
 
 INFO:
-  • [acme-corp/P10] Config version is 0.3.0, current GSP is 0.5.0
-    → Fix: Re-run /gsp-start to upgrade config
+  • [{instance}/{check}] {message}
 
 ─── Summary ───────────────────────────
 
-{If score >= 90:} "Project is healthy. Ship it! 🚀"
-{If score >= 70:} "Project has minor issues. Address warnings when convenient."
-{If score >= 50:} "Project needs attention. Fix the warnings above."
-{If score < 50:}  "Project has significant issues. Address failures first."
+{summary line based on score band}
 ```
 
-Health emoji: 90-100: 💚, 70-89: 💛, 50-69: 🟠, 0-49: ❤️
-Health bar: 20-char using █ and ░.
+**Verdict glyphs:** ✅ PASS · ⚠️ WARN · ❌ FAIL · ℹ️ INFO
+**Health emoji:** 90–100: 💚 · 70–89: 💛 · 50–69: 🟠 · 0–49: ❤️
+**Health bar:** 20-char using █ and ░.
+
+**Summary lines by score band:**
+- `≥ 90` — "Project is healthy. Ship it! 🚀"
+- `70–89` — "Project has minor issues. Address warnings when convenient."
+- `50–69` — "Project needs attention. Fix the warnings above."
+- `< 50` — "Project has significant issues. Address failures first."
 
 ## Important Notes
 

--- a/gsp/skills/gsp-doctor/checks.md
+++ b/gsp/skills/gsp-doctor/checks.md
@@ -1,0 +1,259 @@
+# Doctor check catalog
+
+Detailed check definitions loaded on demand by `gsp-doctor/SKILL.md` Step 3. Each check below describes what it catches, how it runs, and the verdict thresholds. Run only the check sets applicable to the detected structure (B for brands, P for projects, I and S for installation health, X for cross-instance).
+
+## Per-Brand Checks (4-phase)
+
+**Check B1: Brand Structure**
+Required: config.json, STATE.md, BRIEF.md
+Required dirs: discover/, strategy/, identity/, patterns/
+Missing → FAIL
+
+**Check B2: Brand Phase Ordering**
+No phase complete if earlier phase is pending (discover < strategy < identity < patterns).
+Exception: strategy can proceed without discover.
+
+**Check B3: Brand Completeness**
+If all 4 phases complete, check:
+- `identity/INDEX.md` exists (chunk format)
+- `identity/palettes.json` exists (WARN if missing)
+- `patterns/INDEX.md` exists (chunk format)
+- `patterns/*.yml` preset exists (WARN if missing)
+- If monolith exists without INDEX.md → WARN: "Legacy monolith format"
+
+**Check B4: Legacy Monolith Detection**
+For each brand phase directory (discover, strategy, identity, patterns):
+- If monolith exists but no INDEX.md → WARN: "Monolith files are no longer supported in GSP v0.6.0+. Re-run `/gsp-brand-{phase}` to generate chunk output."
+
+## Per-Project Checks (6-phase)
+
+**Check P1: Project Structure**
+
+**What it catches:** Missing core files, incomplete setup.
+
+Required: config.json, STATE.md, BRIEF.md, brand.ref
+Required dirs: brief/, research/, design/, critique/, build/, review/
+
+Check each exists:
+- All present → PASS
+- Core files missing → FAIL: list which are missing, suggest `/gsp-start`
+
+**Monorepo app_path check:**
+- If `repo_type` is `monorepo` (in config.json) and `app_path` is empty → WARN: "Project has no `app_path` set. Run `/gsp-project-brief` to assign a target app."
+
+**Design system check:**
+- If `.design/system/` directory exists, verify at least `STACK.md` is present → PASS
+- If `.design/system/` is missing and codebase is not greenfield → WARN: "Design system scan missing. Run `/gsp-design-system` to scan."
+- If old project-scoped `codebase/INVENTORY.md` exists → WARN: "Legacy INVENTORY.md found. Run `/gsp-design-system` to migrate to workspace-level design system docs."
+
+Legacy detection: if system/, screens/, specs/, plan/ dirs exist → WARN: "Legacy structure detected — project uses old phase layout"
+
+**Check P2: Brand Reference**
+Read brand.ref → check brand exists in `.design/branding/{name}/`
+Check brand system is complete (system phase = complete)
+WARN if brand referenced but system not complete
+
+**Check P3: Brand Drift**
+Read `identity_hash` from brand.ref
+If brand identity/IDENTITY.md exists, compute current hash (first 8 chars of md5)
+If hashes differ → WARN: "Brand identity has changed since project consumed it. Consider re-running `/gsp-project-brief`."
+If identity_hash is "pending" → INFO: "Brand identity wasn't complete when project was created."
+
+**Check P4: Phase Ordering**
+
+**What it catches:** Phases completed out of order, skipped prerequisites.
+
+Read STATE.md phase table. Check ordering rules:
+brief < research < design < critique < build < review
+
+1. No phase should be `complete` if an earlier required phase is still `pending` (not `skipped` or `complete`)
+2. Valid skip scenarios (not violations):
+   - design skipped when `design_scope` is `tokens`
+   - research can proceed without brief
+3. build complete but critique pending → WARN: "Build completed without critique. Run `/gsp-project-critique` to audit."
+4. Any other out-of-order completion → FAIL with specifics
+
+All phases in order (or validly skipped) → PASS
+
+**Check P5: Stale Outputs**
+
+**What it catches:** Output content that doesn't match current config expectations.
+
+Only check phases that are `complete`. All paths relative to the project instance directory.
+
+**When `system_strategy` is `extend`:**
+- Check if brand's `patterns/` output contains "Component Audit" or "KEEP" or "RESTYLE" or "REFACTOR" or "REPLACE"
+- If none found → WARN: "Strategy is `extend` but system output lacks component audit table. Re-run `/gsp-brand-guidelines`."
+
+**When `implementation_target` is `shadcn`:**
+- If brief phase is complete, check brief/ output for "shadcn" or "npx shadcn"
+- If not found → WARN: "Target is `shadcn` but brief doesn't reference shadcn components."
+
+**When `implementation_target` is `rn-reusables`:**
+- If brief phase is complete, check brief/ output for "reusables" or "NativeWind"
+- If not found → WARN: "Target is `rn-reusables` but brief doesn't reference RN Reusables."
+
+**When `design_scope` is `tokens`:**
+- design phase should be `skipped`, not `complete`
+- If `complete` → WARN: "Scope is `tokens` but design phase ran as full. Outputs may be unnecessary."
+
+No stale outputs detected → PASS
+
+**Check P6: Config Drift**
+
+**What it catches:** Config says one thing, outputs reflect another.
+
+**Check `system_strategy` alignment:**
+- Config says `extend` but brand system output contains "## Components" with 30+ component specs (no audit table) → WARN: "Config says `extend` but system looks like a full `generate`. Config may be out of sync."
+- Config says `generate` but brand system output contains "Component Audit" → WARN: "Config says `generate` but system contains extend-style audit."
+
+**Check `codebase_type` alignment:**
+- Config says `existing` or `boilerplate` but no `.design/system/STACK.md` → WARN (already caught by P1, don't double-count)
+- Config says `greenfield` but `.design/system/STACK.md` exists → INFO: "Config says `greenfield` but design system docs exist. Not an issue, but config may be stale."
+
+**Check `design_scope` alignment:**
+- Config says `tokens` but design/ has full screen designs → WARN: "Scope is `tokens` but design/ has full screen designs."
+- Config says `partial` — check BRIEF.md for "Target screens" section. If missing → WARN: "Scope is `partial` but BRIEF.md doesn't specify target screens."
+
+No drift detected → PASS
+
+**Check P7: Missing Chunks**
+
+**What it catches:** Chunk directories missing, INDEX.md references broken.
+
+For each completed project phase (brief, research, design, critique, build, review):
+- Check for `{phase}/INDEX.md` — if missing → WARN: "Phase {phase} is complete but has no INDEX.md. Re-run `/gsp-{command}` to generate chunks."
+
+**If exports/INDEX.md exists, check for broken references:**
+- Read INDEX.md, extract all file paths from markdown links
+- Check each referenced file exists
+
+Broken INDEX.md references → WARN: list broken paths
+INDEX.md has unpopulated BEGIN/END sections for completed phases → WARN: "INDEX.md has empty sections for completed phases."
+
+No chunks expected yet (no phases complete) → PASS
+All chunks present and references valid → PASS
+
+Legacy path detection: if `screens/` exists instead of `design/` → WARN
+
+**Check P8: Broken References**
+
+**What it catches:** Cross-file references that point to non-existent content.
+
+**design/ → brand system:**
+If both exist, extract component names referenced in design chunks (look for patterns like "Uses: {ComponentName}" or component references). Check each exists in the brand's system output.
+
+Components referenced in designs but not in system → WARN: "Design references components not defined in brand system: {list}. Re-run `/gsp-brand-guidelines` to add them, or update designs."
+
+**critique/ → design/:**
+If both exist, extract screen references from critique chunks. Check each referenced screen exists in design/.
+
+Screens referenced in critique but not in designs → WARN: "Critique references screens not in design/: {list}."
+
+No broken references → PASS
+
+**Check P9: Review Status**
+
+**What it catches:** Stuck review loops, unaddressed critical issues.
+
+Read STATE.md review loop table:
+- Count review iterations
+- If > 3 iterations → WARN: "Review has looped {N} times. Consider addressing root causes or accepting current state."
+
+If critique phase status is `needs-revision`:
+- Check if any later phase (build, review) is `complete` → FAIL: "Build/Review completed while critique still needs revision."
+
+If critique/ contains chunks with "Critical" severity items:
+- If critique phase status is `complete` (not `needs-revision`) → INFO: "Critique has critical items but phase is marked complete. Verify issues were addressed."
+
+No review issues → PASS
+
+**Check P10: Upgrade Detection**
+
+**What it catches:** Project created with older GSP version, missing features now available.
+
+**Config version check:**
+- If `version` field exists in config.json, note it
+- If version is older than current (0.5.0) → WARN: "Config version is {version}, current GSP is 0.5.0. Some features may not be active."
+- If no `version` field → INFO: "Config has no version stamp. Project may predate versioned configs."
+
+**Chunk format check:**
+- If any phase is complete but has no INDEX.md and no chunk files → WARN: "Project may predate chunked exports. Consider re-running phases to get chunked output."
+
+**palettes.json check:**
+- If brand's identity phase is complete, check for `identity/palettes.json`
+- If missing → INFO: "No tints.dev palettes found. Re-run `/gsp-brand-identity` to generate OKLCH color palettes."
+
+No upgrade concerns → PASS
+
+## Installation Health Checks
+
+**Check I1: Skills have `user-invocable: true`**
+Glob for all SKILL.md files in the skills directory (`{runtime-dir}/skills/*/SKILL.md` — e.g. `.claude/skills/` for Claude Code, `.opencode/skills/` for OpenCode, `.gemini/skills/` for Gemini). For each skill (except the entry point `get-shit-pretty`), check frontmatter for `user-invocable: true`.
+- All present → PASS
+- Missing → WARN: "Skills missing `user-invocable: true`: {list}. They won't appear in the slash-command menu. Re-run the installer or add the field manually."
+
+**Check I2: Skill directories are complete (not just SKILL.md)**
+For each gsp-* skill directory, check if `SKILL.md` references sibling files via `${CLAUDE_SKILL_DIR}/` paths (e.g. `styles/INDEX.yml`). If it does, verify those files/dirs exist in the installed skill directory.
+- All referenced siblings present → PASS
+- Missing siblings → FAIL: "Skill {name} references {path} but it's missing. Re-run the installer: `pnpm dlx get-shit-pretty` (or `bunx get-shit-pretty`)"
+
+**Check I3: Bundle directories accessible**
+Check that the runtime bundle directories exist (`{runtime-dir}/templates/`, `{runtime-dir}/references/`). Skills reference these via `${CLAUDE_SKILL_DIR}/../../`.
+- All present → PASS
+- Missing → FAIL: "Bundle directory {dir} missing. Re-run the installer: `pnpm dlx get-shit-pretty` (or `bunx get-shit-pretty`)"
+
+**Check I4: VERSION file present**
+Check `{runtime-dir}/VERSION` exists and contains a valid semver string.
+- Present and valid → PASS (show version)
+- Missing → WARN: "VERSION file missing. Re-run the installer."
+- Mismatched with source → INFO: "Installed version {installed} differs from source {source}."
+
+**Check I5: No duplicate skills (stale global install)**
+Check if `~/.claude/skills/` contains `gsp-*` directories when running from a local install. These cause duplicates between global and local.
+- Run: `ls ~/.claude/skills/ | grep '^gsp-'`
+- No matches → PASS
+- Matches found → FAIL: "Found {N} stale GSP skills in ~/.claude/skills/. Fix: run `pnpm dlx get-shit-pretty --claude --local` (or `bunx get-shit-pretty --claude --local`) to reinstall (the installer cleans stale globals automatically), or manually remove: `rm -rf ~/.claude/skills/gsp-*`"
+
+## Stack Compliance Checks (shadcn targets)
+
+Only run these checks when `.design/system/STACK.md` exists and at least one project has `implementation_target: shadcn`.
+
+> **Monorepo note:** For monorepos, each project's S-checks run in its declared `app_path`. Read `config.json` → `preferences.app_path` before running commands. If `app_path` is empty, run in repo root.
+
+**Check S1: Alias drift**
+
+Read `config.json` → `preferences.app_path`. Set `APP_PATH` (default `.` if empty).
+
+Run `cd {APP_PATH} && npx shadcn@latest info --json` and extract `aliases.components`. Compare to `## Key Paths → Components` in STACK.md.
+
+If mismatch → FAIL: "shadcn alias drift — STACK.md declares `{declared}` but live config has `{live}`. Imports will break. Fix by updating `components.json` or `STACK.md`."
+
+**Check S2: Tailwind version drift**
+
+Run `cd {APP_PATH} && node -e "console.log(require('tailwindcss/package.json').version)"`. Compare major version to `## Tech Stack → Styling` in STACK.md.
+
+If major version differs → FAIL: "Tailwind version drift — STACK.md declares `{declared}` but `{live}` is installed. Run `/gsp-scaffold` to realign or update STACK.md."
+
+**Check S3: Icon library drift**
+
+Read `components.json` → `iconLibrary`. Compare to icon library recorded in STACK.md (if present).
+
+If mismatch → WARN: "Icon library drift — STACK.md declares `{declared}` but `components.json` says `{live}`. Agents may import from the wrong package."
+
+**Check S4: Token presence in globals.css**
+
+Find the global CSS file (from `cd {APP_PATH} && npx shadcn@latest info --json` → `tailwindCssFile`, or glob for `globals.css` inside `APP_PATH`). Check it contains `--background`, `--foreground`, `--primary` CSS custom properties.
+
+If missing → WARN: "CSS custom properties not found in `{file}`. Token integration may be incomplete. Run `/gsp-project-build` foundations phase to regenerate."
+
+**Check S5: Tailwind v4 source scoping (if Tailwind v4)**
+
+If Tailwind v4 detected, check `globals.css` for `@import "tailwindcss"`. If present without `source(...)` modifier, and the repo contains non-source directories with Tailwind class names (like `.design/`) → WARN: "Tailwind v4 source not scoped. Add `source(\"../\")` to avoid scanning `.design/` spec files."
+
+All S checks pass → single PASS line: "S1-S5. Stack compliance .......... PASS"
+
+## Cross-Instance
+
+**Check X1: Multiple projects, same brand**
+If multiple projects reference the same brand, and brand has changed since any project consumed it → WARN with list of affected projects.


### PR DESCRIPTION
## Summary
- Closes #181 (under #83 token-budget umbrella).
- Extracted the full check catalog (B1–B4, P1–P10, I1–I5, S1–S5, X1) verbatim into `gsp/skills/gsp-doctor/checks.md`.
- `SKILL.md` now keeps just the orchestration: directory detection, structure scan, a check-dispatch table at Step 3, scoring, and the terminal output template.

## Numbers
- Body: **400L → 149L** (clears the 300L P1 line budget with margin)
- Token-budget score: **400 → 149** (`checks.md` is loaded on demand via Read at Step 3, not declared in `<execution_context>`, so it doesn't count toward the score)

## Functionality
Every check definition, threshold, fix suggestion, and verdict label is preserved verbatim in `checks.md`. The orchestrator routes the same way it did before — the only behavioral change is that the catalog is read once at Step 3 instead of being inlined.

## Acceptance (from #181)
- [x] Body ≤ 280L
- [x] Audit no longer flags `gsp-doctor` in P1 warnings
- [x] Functionality unchanged

## Test plan
- [ ] Run `/gsp-doctor` against a working project with brand + project + shadcn target → confirm same output structure (sections, glyphs, summary line).
- [ ] Run against a project missing `brand.ref` → confirm P1 still FAILs with the same fix suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)