### PR TITLE
chore: add WHEN-not-WHAT triggers to 12 skill descriptions

### DIFF
--- a/gsp/skills/gsp-add-reference/SKILL.md
+++ b/gsp/skills/gsp-add-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-add-reference
-description: Add reference material to a project
+description: Add reference material to a project — use when: add a reference, save inspiration, attach examples, link this site as reference, drop in a moodboard
 user-invocable: true
 allowed-tools:
   - Read

--- a/gsp/skills/gsp-art/SKILL.md
+++ b/gsp/skills/gsp-art/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-art
-description: "Craft ASCII art interactively — you direct, the artist creates"
+description: "Craft ASCII art interactively — you direct, the artist creates — use when: make ASCII art, terminal art, decorative banner, splash screen, hero ASCII"
 user-invocable: true
 allowed-tools:
   - Read

--- a/gsp/skills/gsp-brand-audit/SKILL.md
+++ b/gsp/skills/gsp-brand-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-brand-audit
-description: Audit an existing brand before evolving it
+description: Audit an existing brand before evolving it — use when: audit our brand, what do we have, before a rebrand, brand health check, current brand state, brand inventory
 user-invocable: true
 allowed-tools:
   - Read

--- a/gsp/skills/gsp-brand-sync/SKILL.md
+++ b/gsp/skills/gsp-brand-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-brand-sync
-description: Sync brand to match a project's shipped state — tokens, voice, visual patterns, personality
+description: Sync brand to match a project's shipped state — tokens, voice, visual patterns, personality — use when: brand drifted from the app, reverse-engineer the brand, the code is ahead of the brand docs, sync brand to shipped, update brand from production
 user-invocable: true
 allowed-tools:
   - Read

--- a/gsp/skills/gsp-color/SKILL.md
+++ b/gsp/skills/gsp-color/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-color
-description: "Design color systems — palettes, contrast, semantic mapping, dark mode"
+description: "Design color systems — palettes, contrast, semantic mapping, dark mode — use when: pick colors, build a palette, semantic tokens, dark mode pairings, brand color, accent color"
 user-invocable: true
 allowed-tools:
   - Read

--- a/gsp/skills/gsp-icons/SKILL.md
+++ b/gsp/skills/gsp-icons/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-icons
-description: Design icon systems — library selection, sizing, containers, custom SVG direction
+description: Design icon systems — library selection, sizing, containers, custom SVG direction — use when: pick an icon library, icon sizing rules, icon containers, custom SVG direction, swap icons, icon strategy
 user-invocable: true
 allowed-tools:
   - Read

--- a/gsp/skills/gsp-logo/SKILL.md
+++ b/gsp/skills/gsp-logo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-logo
-description: Design logo directions — concepts, variations, usage rules, and clear space
+description: Design logo directions — concepts, variations, usage rules, and clear space — use when: design the logo, logo concepts, logo variations, lockups, wordmark vs mark, clear space rules, logo usage
 user-invocable: true
 allowed-tools:
   - Read

--- a/gsp/skills/gsp-polish/SKILL.md
+++ b/gsp/skills/gsp-polish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-polish
-description: Detect and fix AI-slop craft failures in the codebase — scrolling text without fade mask, default chart palettes, lorem placeholders, missing empty states, hardcoded hex outside tokens. Auto-runs after build; user-invocable anytime.
+description: Detect and fix AI-slop craft failures in the codebase — auto-runs after build; user-invocable anytime — use when: polish the build, clean up AI slop, find lorem placeholders, missing empty states, default chart palettes, hardcoded hex outside tokens, scrolling text without fade mask
 user-invocable: true
 allowed-tools:
   - Read

--- a/gsp/skills/gsp-start/SKILL.md
+++ b/gsp/skills/gsp-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-start
-description: Start the GSP pipeline — use when starting a new feature, I want to build X, help me design, let's work on, or kicking off any new work
+description: Start the GSP pipeline — routes to the right entry point (brand brief, project brief, scaffold) — use when: starting a new feature, I want to build X, help me design, let's work on, kicking off new work, where do I start
 user-invocable: true
 allowed-tools:
   - Read

--- a/gsp/skills/gsp-style/SKILL.md
+++ b/gsp/skills/gsp-style/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-style
-description: Apply a design style — get tokens and foundations without the branding diamond
+description: Apply a design style preset — tokens and foundations without the full branding diamond — use when: just give me a style, quick tokens, skip branding, apply a preset, use the X style, swap to Y style
 user-invocable: true
 allowed-tools:
   - Read

--- a/gsp/skills/gsp-typography/SKILL.md
+++ b/gsp/skills/gsp-typography/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-typography
-description: "Design type systems — scale, pairing, fluid type, vertical rhythm"
+description: "Design type systems — scale, pairing, fluid type, vertical rhythm — use when: pick fonts, font pairing, type scale, vertical rhythm, fluid typography, body and heading sizes"
 user-invocable: true
 allowed-tools:
   - Read

--- a/gsp/skills/gsp-visuals/SKILL.md
+++ b/gsp/skills/gsp-visuals/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gsp-visuals
-description: "Define visual direction — imagery, 3D, video, textures, and surface treatments"
+description: "Define visual direction — imagery, 3D, video, textures, and surface treatments — use when: pick imagery, set mood, choose visual treatment, 3D direction, video direction, texture and surface decisions"
 user-invocable: true
 allowed-tools:
   - Read


### PR DESCRIPTION
## Why

The harness-doctor pass flagged 12 skill descriptions that described *what they do* instead of *when to use them*. Mechanical fix — adding `use when: <triggers>` so natural phrasing routes correctly.

## What

| Group | Skills |
|---|---|
| Brand | `gsp-brand-audit`, `gsp-brand-sync` |
| Expertise | `gsp-color`, `gsp-typography`, `gsp-visuals`, `gsp-icons`, `gsp-logo`, `gsp-style` |
| Build helpers | `gsp-polish` |
| Utilities | `gsp-add-reference`, `gsp-art`, `gsp-start` (tightened existing weak triggers) |

## Intentionally skipped

These 5 descriptions stay trigger-less — they're invoked by `/command` or by other skills, not by natural phrasing:
- `get-shit-pretty` (umbrella manifest entry)
- `gsp-help`, `gsp-pretty`, `gsp-update` (utility CLI)
- `gsp-phase-transition` (internal, called by pipeline skills)

## Scope

Frontmatter `description:` field only. No logic, no body, no cross-skill references touched. 12 single-line edits.

## Audit
- **77 PASS · 3 WARN · 0 FAIL** — same warning set as before (the 3 are pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)