### PR TITLE
harness: wire PreToolUse runtime-dir guard into gsp/hooks/hooks.json + cover MultiEdit

### DIFF
--- a/claude-settings.template.json
+++ b/claude-settings.template.json
@@ -6,7 +6,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -21,7 +21,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/gsp/hooks/hooks.json
+++ b/gsp/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_ROOT}/scripts/check-runtime-edit.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "compact",


### PR DESCRIPTION
## Why

The harness-doctor pass surfaced that CLAUDE.md's "Never edit inside .claude/, .opencode/, …" rule was prose-only in `gsp/hooks/hooks.json` — the single-source-of-truth hook contract checked by H1/H2 in the audit suite. The guard script (`scripts/check-runtime-edit.sh`) and a PreToolUse wiring in `claude-settings.template.json` already existed, but:

1. **`gsp/hooks/hooks.json` had no PreToolUse block** — only SessionStart + SubagentStop lived there.
2. **Both files matched only `Edit|Write`** — missing `MultiEdit`, which also writes to `file_path` and should pass through the same guard.

## What

1. Added a PreToolUse block to `gsp/hooks/hooks.json` mirroring the template:
   ```json
   "PreToolUse": [
     {
       "matcher": "Edit|Write|MultiEdit",
       "hooks": [{ "type": "command", "command": "bash ${CLAUDE_PROJECT_ROOT}/scripts/check-runtime-edit.sh" }]
     }
   ]
   ```
2. Widened the matchers in `claude-settings.template.json` (both PreToolUse and PostToolUse) from `Edit|Write` → `Edit|Write|MultiEdit`.

Guard script **unchanged** — it already reads `.tool_input.file_path`, which `Edit`, `Write`, and `MultiEdit` all provide.

## Verified locally

| Scenario | Result |
|---|---|
| `.tool_input.file_path = ".claude/skills/foo/SKILL.md"` | exit 2, BLOCKED with clear message |
| `.tool_input.file_path = "gsp/skills/foo/SKILL.md"` | exit 0, allowed |
| no `file_path` in input | exit 0, fail-open safety |

## Audit
- **77 PASS · 3 WARN · 0 FAIL** — same warning set as before (3 unrelated pre-existing).
- Both JSON files validate; H2 confirms the guard script path resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)