### PR TITLE
feat(sdd): flat spec.md artifact + EARS acceptance criteria — PR 1 of SDD pivot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to get-shit-pretty are documented here.
 
 ## [Unreleased]
 
+### Architecture
+- **SDD pivot — project pipeline now produces a flat `spec.md` contract.** `/gsp-project-brief` consolidates the five chunked outputs (`scope.md`, `target-adaptations.md`, `install-manifest.md`, `gap-analysis.md`, `file-references.md` + `brief/INDEX.md`) into a single `{PROJECT_PATH}/spec.md` artifact, and adds a required **Acceptance Criteria** section in EARS notation (`WHEN <trigger>, THE SYSTEM SHALL <behavior>`). Downstream skills (research, design, critique, build, review, scaffold) read `spec.md` and verify against the EARS criteria; legacy `brief/` subdirs still readable via fallback. First PR in the spec-driven-development refactor — see also planned merges of design+critique and build+review. ([#232](https://github.com/jubscodes/get-shit-pretty/pull/232))
+
 ### Added
 - **`/gsp-polish`** — detects and fixes AI-slop craft failures in the codebase (scrolling text without fade mask, default chart palettes, lorem placeholders, missing empty states, hardcoded hex outside tokens). Auto-runs after build; user-invocable anytime ([#222](https://github.com/jubscodes/get-shit-pretty/pull/222))
 - **User-declared output modes for the project pipeline** — `preferences.project_size` (`chat` / `compact` / `full`) caps how many chunks each project-phase agent writes. Enforced by the `check-artifact-size.sh` SubagentStop hook ([#221](https://github.com/jubscodes/get-shit-pretty/pull/221) covering [#211](https://github.com/jubscodes/get-shit-pretty/issues/211))

--- a/gsp/policies/output-modes.md
+++ b/gsp/policies/output-modes.md
@@ -24,13 +24,15 @@ Single source of truth for **project-pipeline** output adaptation. Pipeline skil
 
 The chunk *vocabulary* is preserved across all modes — only the **file partitioning** changes. A designer reading any mode sees the same H2 headers (Personas, IA, Component Spec, Microcopy, Accessibility, Visual Design, UX Flows, Responsive, Micro-interactions).
 
-### Brief
+### Brief (SDD spec)
+
+The brief phase is **outside this mode policy**. As of the SDD pivot (PR #232+), the brief always writes a single flat artifact `{PROJECT_PATH}/spec.md` regardless of `project_size`. Sections that have no project-specific content are omitted entirely (skip-if-not-present).
 
 | Mode | Files | Sections |
 |---|---|---|
-| `chat` | none (brief lives in conversation) | scope, target adaptations, install manifest, gap analysis, file references |
-| `compact` | `brief/PHASE.md` (≤300 lines) | same H2 sections |
-| `full` | 5 files: `scope.md`, `target-adaptations.md`, `install-manifest.md`, `gap-analysis.md`, `file-references.md` + `INDEX.md` | one file per concern |
+| any | `{PROJECT_PATH}/spec.md` (flat) | Scope, Acceptance Criteria (EARS), Target Adaptations, Install Manifest, Gap Analysis, File References, Issue Framing |
+
+Legacy projects with `brief/` subdirs still readable; new projects use the flat spec.
 
 ### Research
 

--- a/gsp/skills/gsp-project-brief/SKILL.md
+++ b/gsp/skills/gsp-project-brief/SKILL.md
@@ -18,11 +18,11 @@ Works with the dual-diamond architecture: reads brand system from `.design/brand
 </context>
 
 <objective>
-Scope the project and plan adaptations from the brand system.
+Scope the project, capture testable acceptance criteria, and plan adaptations from the brand system.
 
 **Input:** Brand system (via brand.ref) + project BRIEF.md + config.json
-**Output:** `{project}/brief/` (scope.md, target-adaptations.md, conditionals, INDEX.md)
-**Output mode:** Honor `${CLAUDE_SKILL_DIR}/../../policies/output-modes.md` per `preferences.project_size` (default `compact`). Chunk file counts and consolidation rules live in the policy.
+**Output:** `{project}/spec.md` — single flat artifact (the SDD-style spec contract). Replaces the prior `brief/` subdirectory.
+**Output mode:** Spec is always written flat regardless of `preferences.project_size`. Verbosity within sections still honors the mode policy.
 </objective>
 
 <execution_context>
@@ -118,71 +118,95 @@ If this project modifies components from a sibling's manifest, note provenance.
 
 1. **Analyze brief** — what's being built, for whom, on what platforms
 2. **Define screen list** — prioritized screens from brief, user flows, success criteria
-3. **Map component scope** — which brand system components this project needs
-4. **Identify adaptations** — project-specific variants, overrides, or extensions to brand components
-5. **Map to implementation target** — connect design components to target primitives (shadcn, rn-reusables, existing, code)
-6. **Gap analysis** (existing codebases) — what's in the brand system but missing from the codebase
-7. **Generate install manifest** (shadcn/rn-reusables) — install commands for needed components
-8. **Issue framing** — suggest how to break the project into bounded, shippable issues
+3. **Write acceptance criteria in EARS notation** — each user-visible behavior becomes a testable `WHEN <trigger> THE SYSTEM SHALL <behavior>` line, grouped by feature area, numbered (AC-1.1, AC-1.2, …). These are the contract the design, build, and review phases verify against. Aim for 5–15 criteria total — enough to cover the happy paths and the critical edges, not every keystroke.
+4. **Map component scope** — which brand system components this project needs
+5. **Identify adaptations** — project-specific variants, overrides, or extensions to brand components
+6. **Map to implementation target** — connect design components to target primitives (shadcn, rn-reusables, existing, code)
+7. **Gap analysis** (existing codebases) — what's in the brand system but missing from the codebase
+8. **Generate install manifest** (shadcn/rn-reusables) — install commands for needed components
+9. **Issue framing** — suggest how to break the project into bounded, shippable issues
 
 ### Quality standards
 
 - Every screen has a clear purpose and priority level
+- Every acceptance criterion is testable (could be turned into a test) and unambiguous (no "the system shall be fast")
 - Component adaptations reference specific brand system components
 - Gap analysis is concrete (component names, token names)
 - Install manifests are copy-paste ready
 - Scope boundaries are explicit (what's in, what's out)
 
-### Write chunks to `{PROJECT_PATH}/brief/`
+## Step 3: Write `{PROJECT_PATH}/spec.md`
 
-Use the brief output template from execution_context for chunk formatting.
+Use the spec template from execution_context as the section skeleton.
 
-1. **`scope.md`** (~80-120 lines) — prioritized screen list, component scope, project boundaries, success criteria, dependencies, issue framing
-2. **`target-adaptations.md`** (~60-100 lines) — token overrides, component adaptations, platform considerations, implementation target mapping
-3. **`install-manifest.md`** (shadcn/rn-reusables only) — install commands for all needed components
-4. **`gap-analysis.md`** (existing target only) — components/tokens in brand system but not in codebase
-5. **`file-references.md`** (existing target only) — paths to existing components/tokens being used
+The artifact is **one flat file** at `{PROJECT_PATH}/spec.md` — no `brief/` subdirectory, no per-axis chunks, no `INDEX.md` cross-pollination. Sections that have no project-specific content are omitted entirely (skip-if-not-present doctrine).
 
-Cross-references: `target-adaptations.md` links to `{BRAND_PATH}/patterns/components/{name}.md`; `gap-analysis.md` links to brand system components and tokens; `scope.md` references the project BRIEF.md.
-
-### Write `INDEX.md`
+Section order:
 
 ```markdown
-# Brief
-> Phase: brief | Project: {name} | Generated: {DATE}
+# Spec: {project-name}
 
-## Scoping
+> Project: {name} | Brand: {brand} | Generated: {DATE}
+> Implementation target: {target} | Issue: {url if linked}
 
-| Chunk | File | ~Lines |
-|-------|------|--------|
-| Scope | [scope.md](./scope.md) | ~{N} |
-| Target Adaptations | [target-adaptations.md](./target-adaptations.md) | ~{N} |
-| Install Manifest | [install-manifest.md](./install-manifest.md) | ~{N} |
-| Gap Analysis | [gap-analysis.md](./gap-analysis.md) | ~{N} |
-| File References | [file-references.md](./file-references.md) | ~{N} |
+## Scope
+{2–3 paragraphs on what's being built, for whom, on what platforms.}
+
+### Screens
+| Screen | Priority | Purpose |
+|--------|---------:|---------|
+| ... | P0/P1/P2 | one-liner |
+
+### Boundaries
+**In scope:** …
+**Out of scope:** …
+
+## Acceptance Criteria
+Each criterion uses EARS notation. The design, build, and review phases verify against these.
+
+### {Feature area 1}
+- **AC-1.1** — WHEN <trigger>, THE SYSTEM SHALL <behavior>
+- **AC-1.2** — …
+
+### {Feature area 2}
+- **AC-2.1** — …
+
+## Target Adaptations
+Component adaptations + token overrides for {implementation_target}.
+
+| Component | Adaptation | Reason |
+|-----------|-----------|--------|
+| ... | what changes | why |
+
+## Install Manifest
+(shadcn / rn-reusables targets only — omit otherwise)
+
+\`\`\`bash
+npx shadcn@latest add button card dialog
+npm install lucide-react
+\`\`\`
+
+## Gap Analysis
+(existing codebases only — omit otherwise)
+
+Components/tokens in brand system but not in codebase: …
+
+## File References
+(existing target only — omit otherwise)
+
+| Component | Existing path | Reuse strategy |
+|-----------|---------------|----------------|
+| ... | path | keep / restyle / replace |
+
+## Issue Framing
+How to break this into bounded shippable PRs.
+1. ...
+2. ...
 ```
 
-Only include rows for chunks that were actually produced.
+Cross-references: Target Adaptations links to `{BRAND_PATH}/patterns/components/{name}.md`; Gap Analysis links to brand system components and tokens.
 
-## Step 3: Write exports
-
-Update `{PROJECT_PATH}/exports/INDEX.md`:
-- If INDEX.md doesn't exist, copy it from `templates/exports-index.md`
-- Replace everything between `<!-- BEGIN:brief -->` and `<!-- END:brief -->` with populated table:
-
-```markdown
-<!-- BEGIN:brief -->
-| Section | File |
-|---------|------|
-| Scope | [scope.md](../brief/scope.md) |
-| Target Adaptations | [target-adaptations.md](../brief/target-adaptations.md) |
-| Install Manifest | [install-manifest.md](../brief/install-manifest.md) |
-| Gap Analysis | [gap-analysis.md](../brief/gap-analysis.md) |
-| File References | [file-references.md](../brief/file-references.md) |
-<!-- END:brief -->
-```
-
-Only include rows for chunks that were actually produced.
+**Do not** write `{PROJECT_PATH}/brief/`, `{PROJECT_PATH}/brief/INDEX.md`, or update `{PROJECT_PATH}/exports/INDEX.md`. Those structures are deprecated by the flat-spec shape. If an existing `brief/` directory is present from a pre-SDD project, leave it untouched — `gsp-doctor` surfaces it as legacy.
 
 ## Step 4: Update state
 

--- a/gsp/skills/gsp-project-build/SKILL.md
+++ b/gsp/skills/gsp-project-build/SKILL.md
@@ -176,7 +176,7 @@ Spawn `gsp-project-builder` agent with **execution_mode: foundations**.
 |------|---------|
 | `{BRAND_PATH}/patterns/{brand-name}.yml` | Token values only — used with token-mapping.md to generate CSS variables. Do NOT re-read patterns/constraints/effects from here — those are in STYLE.md. |
 | `{BRAND_PATH}/patterns/STYLE.md` | Design law — philosophy, patterns, constraints, effects, bold bets, implementation hints (if exists; fall back to `{brand-name}.md`) |
-| `{PROJECT_PATH}/brief/target-adaptations.md` | Component adaptations for target |
+| `{PROJECT_PATH}/spec.md` (or legacy `{PROJECT_PATH}/brief/target-adaptations.md`) | SDD spec — read **Target Adaptations** section. Builder also verifies output against the spec's **Acceptance Criteria**. |
 | `.design/system/STACK.md` | Stack state (or `.design/system/stacks/{APP_NAME}.md` for monorepos) |
 | `.design/system/CONVENTIONS.md` | Codebase conventions (if exists) |
 | `.design/system/COMPONENTS.md` | Existing components (if exists) |
@@ -292,7 +292,7 @@ Context per component agent:
 | `{BRAND_PATH}/patterns/{brand-name}.yml` | Token values |
 | `{BRAND_PATH}/patterns/components/token-mapping.md` | Component-to-token mapping |
 | Design chunk excerpts (only sections referencing these components) | Usage context — how screens use them |
-| `{PROJECT_PATH}/brief/target-adaptations.md` | Component adaptations for target |
+| `{PROJECT_PATH}/spec.md` (or legacy `{PROJECT_PATH}/brief/target-adaptations.md`) | SDD spec — read **Target Adaptations** section. Builder also verifies output against the spec's **Acceptance Criteria**. |
 | `{PROJECT_PATH}/config.json` | Tech stack, implementation target |
 | Visual effects, block patterns refs (loaded in Step 2.6) | Design patterns + CSS recipes |
 | Agent methodology (loaded in Step 2.5) | Builder role, process, quality standards |
@@ -332,7 +332,7 @@ Build all screens in parallel. Components exist in the codebase from Phase 4.
 |------|---------|
 | `{PROJECT_PATH}/design/screen-{NN}-{name}.md` | This screen's design chunk |
 | Component file paths from BUILD-LOG.md components section | Where to import from (paths only — agent reads codebase) |
-| `{PROJECT_PATH}/brief/target-adaptations.md` | Component adaptations |
+| `{PROJECT_PATH}/spec.md` (or legacy `{PROJECT_PATH}/brief/target-adaptations.md`) | SDD spec — **Target Adaptations** section + relevant **Acceptance Criteria** |
 | `{PROJECT_PATH}/research/reference-specs.md` (if exists) | Technical specs — include only sections relevant to this screen |
 | `{PROJECT_PATH}/critique/prioritized-fixes.md` (if exists) | Critique fixes — include only fixes tagged to this screen |
 | Build output template (from execution_context) | Build log structure |

--- a/gsp/skills/gsp-project-build/component-classification.md
+++ b/gsp/skills/gsp-project-build/component-classification.md
@@ -3,8 +3,7 @@
 ## Build component manifest
 
 Read ALL design chunks from `{PROJECT_PATH}/design/` — every `screen-{NN}-{name}.md`. Also read:
-- `{PROJECT_PATH}/brief/scope.md` (feature map)
-- `{PROJECT_PATH}/brief/target-adaptations.md` (component adaptations)
+- `{PROJECT_PATH}/spec.md` — **Scope** (feature map) + **Target Adaptations** (component adaptations). Legacy fallback: `{PROJECT_PATH}/brief/scope.md` and `{PROJECT_PATH}/brief/target-adaptations.md`.
 - `{BRAND_PATH}/patterns/components/token-mapping.md` (if exists)
 
 Extract every component referenced across all screens. Deduplicate. Build a manifest:

--- a/gsp/skills/gsp-project-build/flows/figma.md
+++ b/gsp/skills/gsp-project-build/flows/figma.md
@@ -19,7 +19,7 @@ Spawn a single `gsp-project-builder` agent with:
 - `spec_only: true`
 - All design chunks from `{PROJECT_PATH}/design/` inlined
 - Brand system: `{BRAND_PATH}/patterns/STYLE.md` and `{BRAND_PATH}/patterns/{brand-name}.yml`
-- Brief: `{PROJECT_PATH}/brief/target-adaptations.md` and `{PROJECT_PATH}/brief/scope.md`
+- Spec: `{PROJECT_PATH}/spec.md` — **Target Adaptations**, **Scope**, **Acceptance Criteria**. Legacy fallback: `{PROJECT_PATH}/brief/target-adaptations.md` and `{PROJECT_PATH}/brief/scope.md`.
 - Agent methodology (loaded in Step 2.5 of main flow)
 
 Agent instructions:

--- a/gsp/skills/gsp-project-build/methodology/gsp-project-builder.md
+++ b/gsp/skills/gsp-project-build/methodology/gsp-project-builder.md
@@ -61,7 +61,7 @@ Legacy mode — build everything in one pass. Used as backward-compatible defaul
 ## Step 0: Plan Before Building
 
 Before writing any code:
-1. Read all design specs, `.design/system/` docs (STACK, COMPONENTS, CONVENTIONS), and brief/target-adaptations
+1. Read all design specs, `.design/system/` docs (STACK, COMPONENTS, CONVENTIONS), and `{PROJECT_PATH}/spec.md` (Target Adaptations + Acceptance Criteria; legacy fallback: `brief/target-adaptations.md`)
 2. Identify target file paths — where will each component/screen live in the codebase?
 3. Outline the implementation plan: what files to create, what files to modify, what order
 4. If `.design/system/` docs exist, follow the codebase's conventions (naming, imports, file structure, styling approach)
@@ -74,7 +74,7 @@ Before writing any code:
 
 ## Translation Process
 
-1. **Map component hierarchy** — From brief/target-adaptations + research/reference-specs (or design if brief was skipped), define the component tree with props, state, and data flow
+1. **Map component hierarchy** — From `spec.md` (Target Adaptations + Acceptance Criteria) + research/reference-specs (or design if spec was skipped), define the component tree with props, state, and data flow
 2. **Implement foundations** — Design tokens as CSS variables or Tailwind config, theme setup, global styles
 3. **Apply brand effects** — Implement STYLE.md's bold bets and effects vocabulary: background treatments, interaction techniques, shadow presets, texture overlays. Create utility classes for reuse across screens. Validate against constraints — never/always rules are non-negotiable.
 4. **Build components** — Write each component directly in the codebase, one file per component with full implementation

--- a/gsp/skills/gsp-project-critique/SKILL.md
+++ b/gsp/skills/gsp-project-critique/SKILL.md
@@ -47,7 +47,7 @@ Read `{PROJECT_PATH}/config.json` to get `implementation_target`, `design_scope`
 
 **Design:** Read `{PROJECT_PATH}/design/INDEX.md` → load all chunks.
 
-**Brief:** Read `{PROJECT_PATH}/brief/INDEX.md` → load all chunks (if exists).
+**Spec:** Read `{PROJECT_PATH}/spec.md` — the SDD contract. Critique verifies against the **Acceptance Criteria** section in particular. Fallback: legacy `brief/INDEX.md` → load all chunks (pre-SDD project shape).
 
 **Research:** Read `{PROJECT_PATH}/research/INDEX.md` → load `recommendations.md` (if exists).
 

--- a/gsp/skills/gsp-project-design/SKILL.md
+++ b/gsp/skills/gsp-project-design/SKILL.md
@@ -83,11 +83,13 @@ If not found, fall back to scanning `{BRAND_PATH}/patterns/` for a `.md` file th
 
 If neither found, proceed without it (older brands may not have this file).
 
-### Brief (chunk-first)
+### Spec (SDD-style flat artifact)
 
-Read `{PROJECT_PATH}/brief/INDEX.md`. If it exists, load `scope.md` and `target-adaptations.md`.
+Read `{PROJECT_PATH}/spec.md` — focus on **Scope**, **Acceptance Criteria** (each screen must support its relevant ACs), and **Target Adaptations**.
 
-If brief doesn't exist, proceed without it (brief is informative, not blocking).
+If `spec.md` is absent but legacy `{PROJECT_PATH}/brief/INDEX.md` exists, fall back to loading `brief/scope.md` and `brief/target-adaptations.md` (pre-SDD project shape).
+
+If neither exists, proceed without it (brief is informative, not blocking).
 
 ### Research (chunk-first)
 

--- a/gsp/skills/gsp-project-research/SKILL.md
+++ b/gsp/skills/gsp-project-research/SKILL.md
@@ -44,11 +44,13 @@ Read `{PROJECT_PATH}/brand.ref` → set `BRAND_PATH`.
 
 ## Step 1: Load context
 
-### Brief (chunk-first)
+### Spec (SDD-style flat artifact)
 
-Read `{PROJECT_PATH}/brief/INDEX.md`. If it exists, load `scope.md` and `target-adaptations.md`.
+Read `{PROJECT_PATH}/spec.md` — focus on **Scope**, **Acceptance Criteria**, and **Target Adaptations**.
 
-If brief doesn't exist, tell the user to run `/gsp-project-brief` first.
+If `spec.md` is absent but legacy `{PROJECT_PATH}/brief/INDEX.md` exists, fall back to loading `brief/scope.md` and `brief/target-adaptations.md` (pre-SDD project shape).
+
+If neither exists, tell the user to run `/gsp-project-brief` first.
 
 ### Brand system (selective)
 

--- a/gsp/skills/gsp-project-research/methodology/gsp-project-researcher.md
+++ b/gsp/skills/gsp-project-research/methodology/gsp-project-researcher.md
@@ -50,7 +50,7 @@ Write each chunk following the standard chunk format:
 
 ### Cross-references
 
-- All chunks reference the project brief: `../brief/scope.md`
+- All chunks reference the project spec: `../spec.md` (legacy fallback: `../brief/scope.md`)
 - `recommendations.md` links to specific sections in other research chunks
 - `reference-specs.md` includes external URLs with retrieval dates
 

--- a/gsp/skills/gsp-project-review/SKILL.md
+++ b/gsp/skills/gsp-project-review/SKILL.md
@@ -60,7 +60,7 @@ Also read `{BRAND_PATH}/patterns/{brand-name}.yml` (the brand's token/style sour
 
 **Brand identity (selective):** Read `{BRAND_PATH}/identity/imagery-style.md` (if exists) — needed for imagery audit.
 
-**Brief:** Read `{PROJECT_PATH}/brief/INDEX.md` → load scope and adaptations.
+**Spec:** Read `{PROJECT_PATH}/spec.md` → focus on **Scope**, **Acceptance Criteria** (review verifies each AC), and **Target Adaptations**. Fallback: legacy `brief/INDEX.md` → load scope and adaptations (pre-SDD project shape).
 
 **Research:** Read `{PROJECT_PATH}/research/INDEX.md` → load `reference-specs.md` (to verify specs were followed).
 

--- a/gsp/skills/gsp-scaffold/SKILL.md
+++ b/gsp/skills/gsp-scaffold/SKILL.md
@@ -114,7 +114,7 @@ If `shadcn info` already reports a different `iconLibrary` than the project conf
 
 ## Step 4: Install components from manifest
 
-Read `{PROJECT_PATH}/brief/install-manifest.md` if it exists.
+Read the **Install Manifest** section from `{PROJECT_PATH}/spec.md`. Legacy fallback: `{PROJECT_PATH}/brief/install-manifest.md` (pre-SDD project shape). If neither exists, skip this step.
 
 Parse the manifest for:
 1. **Component install commands** — `npx shadcn@latest add ...` or `npx @react-native-reusables/cli add ...`

--- a/gsp/templates/phases/brief.md
+++ b/gsp/templates/phases/brief.md
@@ -1,53 +1,39 @@
-# Project Brief
+# Spec
 
-## Project: {PROJECT_NAME}
-**Brand:** {BRAND_NAME}
-**Date:** {DATE}
+> This phase produces a single flat artifact: `{PROJECT_PATH}/spec.md`. SDD-style contract that downstream phases read.
 
----
+## Artifact
 
-> This phase scopes the project. Produces planning chunks + INDEX.md in the `brief/` directory.
+`{PROJECT_PATH}/spec.md` — one file, sectioned. No subdirectory, no per-axis chunks, no INDEX. The earlier `brief/{scope,target-adaptations,install-manifest,gap-analysis,file-references}.md` structure is collapsed into sections of this file.
 
-## Chunk Mapping
+## Section reference
 
-### Brief Chunks (`brief/`)
+### `## Scope`
+What's being built, for whom, on what platforms. Followed by a **Screens** table (priority, purpose) and **Boundaries** lists (in scope / out of scope).
 
-| Chunk File | Content |
-|-----------|---------|
-| `scope.md` | Screen/component list, priorities, project boundaries |
-| `target-adaptations.md` | Project-specific component adaptations from the brand system |
-| `install-manifest.md` | Install commands for needed components (conditional — shadcn/rn-reusables only) |
-| `gap-analysis.md` | Components/tokens in design but not in codebase (conditional — existing target only) |
-| `file-references.md` | Paths to existing components/tokens being used (conditional — existing target only) |
+### `## Acceptance Criteria` (EARS)
+Testable, unambiguous behavior contract. Each line uses the form `WHEN <trigger>, THE SYSTEM SHALL <behavior>`. Grouped by feature area, numbered `AC-{N}.{M}`. Aim for 5–15 total — the happy paths + critical edges.
 
-## Content Reference
+These are what design verifies against ("does the screen support AC-2.3?"), what build tests against ("write the test for AC-2.3"), and what review checks ("AC-2.3 passes? Y/N").
 
-Each chunk follows the standard chunk format. Below is the structural reference for what each chunk should contain:
+### `## Target Adaptations`
+Project-specific token overrides and component adaptations. Each row points at the brand-system component being adapted and the project-specific reason.
 
-### scope.md
-- **Screen list:** prioritized list of screens to design and build
-- **Component scope:** which brand system components this project uses
-- **Project boundaries:** what's in scope and out of scope
-- **Success criteria:** measurable outcomes for the project
-- **Dependencies:** external systems, APIs, content needs
-- **Issue framing:** how this project maps to bounded issues/PRs
+### `## Install Manifest`
+(shadcn / rn-reusables targets only — omit otherwise)
+Copy-paste-ready install commands.
 
-### target-adaptations.md
-- **Token overrides:** project-specific token adjustments (if any)
-- **Component adaptations:** brand components that need project-specific variants
-- **Platform considerations:** platform-specific adjustments (mobile, desktop, etc.)
-- **Implementation target mapping:** design components → target primitives (shadcn, rn-reusables, existing, code)
-- Links to brand system components: `{BRAND_PATH}/patterns/components/{name}.md`
+### `## Gap Analysis`
+(existing codebases only — omit otherwise)
+What's in the brand system but missing from the codebase.
 
-### install-manifest.md
-- Install commands for all needed components
-- Only produced for shadcn/rn-reusables targets
+### `## File References`
+(existing target only — omit otherwise)
+Where existing components live, plus reuse strategy (keep / restyle / replace).
 
-### gap-analysis.md
-- Components in brand system but not in project codebase
-- Tokens in brand system but not in project codebase
-- Only produced for existing target codebases
+### `## Issue Framing`
+How to break the project into bounded shippable PRs.
 
-### file-references.md
-- Paths to all existing components/tokens being used
-- Only produced for existing target codebases
+## Skip-if-not-present
+
+Sections without project-specific content are omitted entirely. Do not write "_Nothing meaningful for this project._" Just leave the section out.


### PR DESCRIPTION
## Why

The project pipeline was producing **too many files for any feature size** — 5+ chunks per phase × 6 phases = 30+ files for a 5-screen project in full mode. Even compact mode (default since #221) lands ~7 files plus cross-phase INDEX pollution (downstream skills updating upstream INDEX.md files). And the brief artifact was a sketch, not a contract — no testable acceptance criteria for downstream phases to verify against.

Spec-driven dev systems (Kiro, github/spec-kit, obra/superpowers) all converged on the opposite: **3–5 flat artifacts per project**, no per-phase dirs, no INDEX cross-updates, and an **EARS-notation contract** as the source of truth.

This PR is **step 1 of 4** in pivoting GSP's project pipeline to that shape.

## What changes

### Brief artifact: `brief/` → flat `spec.md`

`/gsp-project-brief` now writes a single `{PROJECT_PATH}/spec.md` with sections for **Scope · Acceptance Criteria (EARS) · Target Adaptations · Install Manifest · Gap Analysis · File References · Issue Framing**. The old `brief/{scope,target-adaptations,install-manifest,gap-analysis,file-references}.md + INDEX.md` layout is gone.

### EARS-notation acceptance criteria

New required scoping step: capture 5–15 user-visible behaviors as

```
WHEN <trigger>, THE SYSTEM SHALL <behavior>
```

Numbered (`AC-1.1`, `AC-1.2`, …), grouped by feature area. These become the testable contract:
- design verifies screens cover the relevant ACs
- build can test against them
- review checks them as pass/fail in PR 3

### Downstream reads updated

All five downstream skills (`gsp-project-research`, `-design`, `-critique`, `-build`, `-review`) plus `gsp-scaffold`, plus three methodology / sibling files, now prefer `spec.md`. Legacy fallback to `brief/{scope,target-adaptations,...}.md` is preserved so pre-SDD projects keep working — no breaking change.

### Output-modes policy

`gsp/policies/output-modes.md` updated: the brief phase is **outside** the chat/compact/full mode policy — spec is always written flat. Skip-if-not-present doctrine still applies inside the file.

## File reduction (per project)

| Mode | Before | After |
|---|---|---|
| full | `brief/` + 5 chunks + INDEX = **6 files** | `spec.md` = **1 file** |
| compact | `brief/PHASE.md` + INDEX = **2 files** | `spec.md` = **1 file** |

Per-project net: **-1 to -5 files**. PRs 2–4 will repeat this pattern for design, critique, build, review.

## What's NOT in this PR (explicit)

- Merging `gsp-project-design` + `gsp-project-critique` → PR 2
- Merging `gsp-project-build` + `gsp-project-review` → PR 3
- New `gsp-project-ship` skill → PR 4
- Updating `gsp-doctor` to enforce `spec.md` presence → deferred to PR 2 (when design starts reading required ACs)

## Backward compatibility

- New projects use the flat shape from this PR onward.
- Old projects with `brief/` subdirs continue working — downstream skills fall back to legacy paths if `spec.md` is missing.
- `gsp-doctor` will surface "legacy brief shape" as INFO in a follow-up, not a failure.

## Audit
- **77 PASS · 3 WARN · 0 FAIL** — same warning set as before (C8 / line budgets / token red zone, all pre-existing and unrelated).
- 14 files changed, 128 insertions / 110 deletions, net +18 lines.
- `gsp-project-brief/SKILL.md` body: 204L → 228L (under 300L budget).

## Test plan
- [ ] Run `/gsp-project-brief` on a fresh project → confirm `spec.md` written, no `brief/` dir created, Acceptance Criteria section present with EARS-formatted criteria.
- [ ] Run `/gsp-project-design` against a project with `spec.md` → confirm it reads ACs correctly.
- [ ] Run `/gsp-project-design` against a legacy project with `brief/` subdir but no `spec.md` → confirm fallback works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)